### PR TITLE
Update player.py

### DIFF
--- a/plugin.video.vstream/resources/lib/player.py
+++ b/plugin.video.vstream/resources/lib/player.py
@@ -101,7 +101,6 @@ class cPlayer(xbmc.Player):
         #1 er mode de lecture
         elif (player_conf == '0'):
             self.play(sUrl,item)
-            xbmcplugin.endOfDirectory(sPluginHandle, True, False, False)
             VSlog('Player use Play() method')
         #2 eme mode non utilise
         elif (player_conf == 'neverused'):
@@ -130,7 +129,7 @@ class cPlayer(xbmc.Player):
        
         while self.isPlaying() and not self.forcestop:
         #while not xbmc.abortRequested:
-            try: 
+            try:
                self.currentTime = self.getTime()
                self.totalTime = self.getTotalTime()
                
@@ -144,6 +143,12 @@ class cPlayer(xbmc.Player):
         if not self.playBackStoppedEventReceived:
             self.onPlayBackStopped()
         
+        #Uniquement avec la lecture avec play()
+        if (player_conf == '0'):
+            r = xbmcplugin.addDirectoryItem(handle=sPluginHandle,url=sUrl,listitem=item,isFolder=False)
+            #xbmcplugin.endOfDirectory(sPluginHandle, True, False, False)
+            return r
+            
         VSlog('Closing player')
 
     #fonction light servant par exmple pour visualiser les DL ou les chaines de TV

--- a/plugin.video.vstream/resources/lib/player.py
+++ b/plugin.video.vstream/resources/lib/player.py
@@ -1,14 +1,13 @@
 #-*- coding: utf-8 -*-
 # https://github.com/Kodi-vStream/venom-xbmc-addons
 #
-from resources.lib.gui.guiElement import cGuiElement
 from resources.lib.handler.inputParameterHandler import cInputParameterHandler
 from resources.lib.handler.pluginHandler import cPluginHandler
 from resources.lib.config import cConfig
 from resources.lib.gui.gui import cGui
 from resources.lib.db import cDb
-
-import xbmc, xbmcgui, xbmcplugin, sys
+from resources.lib.util import VSlog,isKrypton,VSerror
+import xbmc, xbmcgui, xbmcplugin
 import xbmcaddon,xbmcvfs
 import time
 
@@ -41,7 +40,7 @@ class cPlayer(xbmc.Player):
         self.playBackStoppedEventReceived = False
         self.forcestop = False        
         
-        cConfig().log("player initialized")
+        VSlog("player initialized")
         
     def clearPlayList(self):
         oPlaylist = self.__getPlayList()
@@ -66,39 +65,53 @@ class cPlayer(xbmc.Player):
             self.Subtitles_file = files
         
     def run(self, oGuiElement, sTitle, sUrl):
-        
+ 
         self.totalTime = 0
         self.currentTime = 0
     
         sPluginHandle = cPluginHandler().getPluginHandle()
-        #meta = oGuiElement.getInfoLabel()
+
         meta = {'label': sTitle, 'title': sTitle}
         item = xbmcgui.ListItem(path=sUrl, iconImage="DefaultVideo.png",  thumbnailImage=self.sThumbnail)
         
         item.setInfo( type="Video", infoLabels= meta )
         
+        #lien dash
+        if sUrl.endswith('.mpd'):
+            if isKrypton() == True:
+                cConfig().setSetting("playerPlay",'2')
+                self.enable_addon("inputstream.adaptive")
+            else:
+                VSerror('Nécessite kodi 17 minimum')
+                return
         #Sous titres
         if (self.Subtitles_file):
             try:
                 item.setSubtitles(self.Subtitles_file)
-                cConfig().log("Load SubTitle :" + str(self.Subtitles_file))               
+                VSlog("Load SubTitle :" + str(self.Subtitles_file))               
                 self.SubtitleActive = True
             except:
-                cConfig().log("Can't load subtitle :" + str(self.Subtitles_file))
-        
+                VSlog("Can't load subtitle :" + str(self.Subtitles_file))
+                
+        player_conf = cConfig().getSetting("playerPlay")
+
         #1 er mode de lecture
-        if (cConfig().getSetting("playerPlay") == '0'):
-            self.play( sUrl, item )
+        if (player_conf == '0'):
+            self.play(sUrl,item)
             xbmcplugin.endOfDirectory(sPluginHandle, True, False, False)
-            cConfig().log('Player use Play() method')
-        #2 eme mode non utilise
-        elif (cConfig().getSetting("playerPlay") == 'neverused'):
-            xbmc.executebuiltin( "PlayMedia("+sUrl+")" )
-            cConfig().log('Player use PlayMedia() method')
+            VSlog('Player use Play() method')
+        #2 eme mode dash
+        elif (player_conf == '2'):
+            item.setProperty('inputstreamaddon','inputstream.adaptive')
+            item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+            xbmcplugin.setResolvedUrl(sPluginHandle, True, listitem=item)
+            VSlog('Player use inputstream addon')
+            #remet settings par defaut
+            cConfig().setSetting("playerPlay",'1')
         #3 eme mode (defaut)
         else:
             xbmcplugin.setResolvedUrl(sPluginHandle, True, item)
-            cConfig().log('Player use setResolvedUrl() method')
+            VSlog('Player use setResolvedUrl() method')
         
         #Attend que le lecteur demarre, avec un max de 20s
         for _ in xrange(20):
@@ -108,12 +121,12 @@ class cPlayer(xbmc.Player):
             
         #active/desactive les sous titres suivant l'option choisie dans la config 
         if (self.SubtitleActive):
-             if (cConfig().getSetting("srt-view") == 'true'):
-                 self.showSubtitles(True)
-                 cGui().showInfo("Sous titre charges", "Sous-Titres", 5)
-	     else:
-		 self.showSubtitles(False)
-                 cGui().showInfo("Sous titre charges, Vous pouvez les activer", "Sous-Titres", 15)
+            if (cConfig().getSetting("srt-view") == 'true'):
+                self.showSubtitles(True)
+                cGui().showInfo("Sous titre charges", "Sous-Titres", 5)
+            else:
+                self.showSubtitles(False)
+                cGui().showInfo("Sous titre charges, Vous pouvez les activer", "Sous-Titres", 15)
 		
        
         while self.isPlaying() and not self.forcestop:
@@ -132,7 +145,7 @@ class cPlayer(xbmc.Player):
         if not self.playBackStoppedEventReceived:
             self.onPlayBackStopped()
         
-        cConfig().log('Closing player')
+        VSlog('Closing player')
 
     #fonction light servant par exmple pour visualiser les DL ou les chaines de TV
     def startPlayer(self):
@@ -145,7 +158,7 @@ class cPlayer(xbmc.Player):
     #Attention pas de stop, si on lance une seconde video sans fermer la premiere
     def onPlayBackStopped( self ):
         
-        cConfig().log("player stoped")
+        VSlog("player stoped")
         
         self.playBackStoppedEventReceived = True
         
@@ -161,7 +174,7 @@ class cPlayer(xbmc.Player):
         
     def onPlayBackStarted(self):
         
-        cConfig().log("player started")
+        VSlog("player started")
         
         #Si on recoit une nouvelle fois l'event, c'est que ca buggue, on stope tout
         if self.playBackEventReceived:
@@ -241,15 +254,30 @@ class cPlayer(xbmc.Player):
         
         try:
             if (sPlayerType == '0'):
-                cConfig().log("playertype from config: auto")
+                VSlog("playertype from config: auto")
                 return xbmc.PLAYER_CORE_AUTO
 
             if (sPlayerType == '1'):
-                cConfig().log("playertype from config: mplayer")
+                VSlog("playertype from config: mplayer")
                 return xbmc.PLAYER_CORE_MPLAYER
 
             if (sPlayerType == '2'):
-                cConfig().log("playertype from config: dvdplayer")
+                VSlog("playertype from config: dvdplayer")
                 return xbmc.PLAYER_CORE_DVDPLAYER
         except:
             return False
+            
+    def enable_addon(self,addon):
+        import json
+        sCheck = {'jsonrpc': '2.0','id': 1,'method': 'Addons.GetAddonDetails','params': {'addonid':'inputstream.adaptive','properties': ['enabled']}}
+        response = xbmc.executeJSONRPC(json.dumps(sCheck))
+        data = json.loads(response)
+        if not 'error' in data.keys():
+            if data['result']['addon']['enabled'] == False:
+                do_json = '{"jsonrpc":"2.0","id":1,"method":"Addons.SetAddonEnabled","params":{"addonid":"inputstream.adaptive","enabled":true}}'
+                query = xbmc.executeJSONRPC(do_json)
+                VSlog("Activation d'inputstream.adaptive")
+            else:
+                VSlog('inputstream.adaptive déjà activé')
+                
+                

--- a/plugin.video.vstream/resources/lib/player.py
+++ b/plugin.video.vstream/resources/lib/player.py
@@ -106,7 +106,7 @@ class cPlayer(xbmc.Player):
         #2 eme mode non utilise
         elif (player_conf == 'neverused'):
             xbmc.executebuiltin( "PlayMedia("+sUrl+")" )
-            cConfig().log('Player use PlayMedia() method')
+            VSlog('Player use PlayMedia() method')
         #3 eme mode (defaut)
         else:
             xbmcplugin.setResolvedUrl(sPluginHandle, True, item)


### PR DESCRIPTION
modif pour lire le format dash via inputstream adapative qui est inclus dans kodi 17 pour les autres versions de kodi c'est pas possible
donc si l'url finis par .mpd vstream vérifie que l'addon est activé si il ne l'est pas  il l'active 
change le setting du player pour utilisé méthode 2 puis remet le settings par défaut a savoir 1