### PR TITLE
Update siteuptobox.py

### DIFF
--- a/plugin.video.vstream/resources/sites/siteuptobox.py
+++ b/plugin.video.vstream/resources/sites/siteuptobox.py
@@ -61,7 +61,7 @@ def showFile():
     oPremiumHandler = cPremiumHandler('uptobox')
 
     if 'uptobox.com' in sUrl:
-        sHtmlContent = oPremiumHandler.GetHtml(sUrl)
+        sHtmlContent = oPremiumHandler.GetHtml(sUrl+'&per_page=1000')
     else:    
         sHtmlContent = oPremiumHandler.GetHtml(BURL)
 


### PR DESCRIPTION
Suppression de la limite d'affichage à 25 lignes (car impossible de faire page suivante), affichage à présent jusqu'à 1000 lignes pour voir le contenu du dossier dans le compte uptobox dans son intégralité.