### PR TITLE
Ajout des films 4k et mode turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ Pour participer directement au projet
 Merci à tous nos généreux donateurs et donatrices. J'évite de mettre vos pseudo en évidence pour ne pas faire de vStream une vitrine, mais sachez que celas me motive, encore merci.
 
 Bon Film ++
+
+Merci

--- a/plugin.video.vstream/resources/lib/download.py
+++ b/plugin.video.vstream/resources/lib/download.py
@@ -491,9 +491,9 @@ class cDownload:
         #status = data[8]
 
         if (cConfig().getSetting('always-use-fastmode') == 'true'):
-        	self.download(url,title,path,True)
+            self.download(url,title,path,True)
         else :
-        	self.download(url,title,path,False)
+            self.download(url,title,path,False)
                 
     def StartDownloadList(self):
         cConfig().showInfo('Information', 'Demarrage de la liste complete')

--- a/plugin.video.vstream/resources/lib/download.py
+++ b/plugin.video.vstream/resources/lib/download.py
@@ -341,7 +341,7 @@ class cDownload:
         
         #recherche d'une extension
         sUrl = sUrl.lower()
-        m = re.search('(flv|avi|mp4|mpg|mpeg)', sUrl)
+        m = re.search('(flv|avi|mp4|mpg|mpeg|mkv)', sUrl)
         if m:
             sTitle = sTitle + '.' + m.group(0)
         else:
@@ -490,7 +490,10 @@ class cDownload:
         #thumbnail = urllib.unquote_plus(data[4])
         #status = data[8]
 
-        self.download(url,title,path)
+        if (cConfig().getSetting('always-use-fastmode') == 'true'):
+        	self.download(url,title,path,True)
+        else :
+        	self.download(url,title,path,False)
                 
     def StartDownloadList(self):
         cConfig().showInfo('Information', 'Demarrage de la liste complete')

--- a/plugin.video.vstream/resources/settings.xml
+++ b/plugin.video.vstream/resources/settings.xml
@@ -8,6 +8,7 @@
         <setting id="playerType" type="enum" values="Auto|MPlayer|DVDPlayer" label="30001" default="2" enable="eq(-1,0)"/>
         <setting id="srt-view" type="bool" label="30002" default="false"/>
         <setting id="deco_color" type="select" label="30010" values="aliceblue|lemonchiffon|lightblue|lightcoral|lightcyan|lightgrey|lightgreen|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lavender|moccasin|pink|plum|powderblue|seashell|coral" default="lightcoral"/>
+        <setting id="always-use-fastmode" type="bool" label="Téléchargement turbo" default="false"/>
     <!-- setting id="param_timeout" label="30027" type="number" default="1000"/-->
 
         <setting label="30031" type="lsep"/>

--- a/plugin.video.vstream/resources/sites/zone_telechargement_ws.py
+++ b/plugin.video.vstream/resources/sites/zone_telechargement_ws.py
@@ -38,6 +38,7 @@ MOVIE_EXCLUS = (URL_MAIN + 'exclus/', 'showMovies') # exclus (films populaires)
 MOVIE_3D = (URL_MAIN + 'films-bluray-3d/', 'showMovies') # films en 3D
 MOVIE_HD = (URL_MAIN + 'films-bluray-hd/', 'showMovies') # films en HD
 MOVIE_HDLIGHT = (URL_MAIN + 'x265-x264-hdlight/', 'showMovies') # films en x265 et x264
+MOVIE_4K = (URL_MAIN + 'film-ultra-hd-4k/', 'showMovies') # films en 4K
 MOVIE_VOSTFR = (URL_MAIN + 'filmsenvostfr/', 'showMovies') # films VOSTFR
 
 MOVIE_ANIME = (URL_MAIN + 'dessins-animes/', 'showMovies') # dessins animes
@@ -81,6 +82,10 @@ def load():
     oOutputParameterHandler = cOutputParameterHandler()
     oOutputParameterHandler.addParameter('siteUrl', MOVIE_HDLIGHT[0])
     oGui.addDir(SITE_IDENTIFIER, MOVIE_HDLIGHT[1], 'Films (x265 & x264)', 'films_hd.png', oOutputParameterHandler)
+
+    oOutputParameterHandler = cOutputParameterHandler()
+    oOutputParameterHandler.addParameter('siteUrl', MOVIE_4K[0])
+    oGui.addDir(SITE_IDENTIFIER, MOVIE_4K[1], 'Films 4K', 'films_hd.png', oOutputParameterHandler)
 
     oOutputParameterHandler = cOutputParameterHandler()
     oOutputParameterHandler.addParameter('siteUrl', MOVIE_ANIME[0])


### PR DESCRIPTION
Ajout des films 4k dans zone-telechargement.ws
Option pour télécharger en mode turbo (fonctionne très bien sur boitier à base de S905 sous LibreElec)