### PR TITLE
Update siteuptobox.py

### DIFF
--- a/plugin.video.vstream/resources/sites/siteuptobox.py
+++ b/plugin.video.vstream/resources/sites/siteuptobox.py
@@ -76,7 +76,7 @@ def showFile():
             if dialog.iscanceled():
                 break
 
-            sTitle = aEntry[1] + ' [' + aEntry[2] + ']'
+            sTitle = aEntry[1] 
             sHosterUrl = aEntry[0]
             
             sDisplayTitle = cUtil().DecoTitle(sTitle)


### PR DESCRIPTION
Cette modification n'apporte rien de + bien au contraire, elle supprime le commentaire taille du fichier entre [ ] à cotés du titre, surtout qu'elle apparaît avant la date du film. Je fais cette demande de modification car Impossible de scrapper avec la taille du fichier dans le titre et difficile de supprimer cette chaine avant de scrapper. Je comprendrai tout à fait si cette modification de code est refusée.