### PR TITLE
Update library.py

### DIFF
--- a/plugin.video.vstream/resources/lib/library.py
+++ b/plugin.video.vstream/resources/lib/library.py
@@ -96,6 +96,10 @@ class cLibrary:
 
             try:
                 #print folder
+                
+                if sTitleGlobal.endswith('FINAL'):
+                     sTitleGlobal = sTitleGlobal[:-5]
+                        
                 folder2 = folder + '/' + sTitleGlobal + '/'
                 
                 if not os.path.exists(folder2):


### PR DESCRIPTION
Bonjour, je poste cette proposition de modification, car lorsqu'on ajoute le dernier épisode d'une série complète de zone de téléchargement à la bibliothèque le dernier le nom du fichier se termine par FINALE . 
VSTREAM crée donc un répertoire supplémentaire : nom_de_la_série_FINALE  en plus du répertoire nom_de_la_série. Le dernier fichier est donc dans un répertoire différent, et le scrapper n'arrive pas ensuite à scrapper le nom du répertoire.