### PR TITLE
Correction barre de progression recherche global

### DIFF
--- a/plugin.video.vstream/default.py
+++ b/plugin.video.vstream/default.py
@@ -224,7 +224,11 @@ def searchGlobal():
 
     for count,result in enumerate(oGui.searchResults):
         text = '%s/%s - %s' % ((count+1/total), total, result['guiElement'].getTitle())
-        cConfig().updateDialogSearch(dialog, total, text)
+
+        if(count == 0):
+            cConfig().updateDialogSearch(dialog, total, text,True)
+        else:
+            cConfig().updateDialogSearch(dialog, total, text)
 
         #result['params'].addParameter('VSTRMSEARCH','True')
 

--- a/plugin.video.vstream/resources/lib/config.py
+++ b/plugin.video.vstream/resources/lib/config.py
@@ -214,7 +214,11 @@ class cConfig():
             dialog.update(iPercent, 'Chargement: '+str(cConfig.COUNT)+'/'+str(total))
             cConfig.COUNT += 1
 
-    def updateDialogSearch(self, dialog, total, site):
+    def updateDialogSearch(self, dialog, total, site, resetCount = False):
+
+        if (resetCount == True):
+            cConfig.COUNT=0
+
         iPercent = int(float(cConfig.COUNT * 100) / total)
         dialog.update(iPercent, 'Chargement: '+str(site))
         cConfig.COUNT += 1


### PR DESCRIPTION
Bonjour,
Petite correction sur la barre de recherche pour réinitialiser le compteur lors de la recherche global pendant la phase de recherche des items sinon cela ajout le nombre de source en plus