### PR TITLE
Fixed Visual searches for series by 'Genres' 

### DIFF
--- a/plugin.video.vstream/resources/sites/themoviedb_org.py
+++ b/plugin.video.vstream/resources/sites/themoviedb_org.py
@@ -14,6 +14,7 @@ from resources.lib.tmdb import cTMDb
 
 try:    import json
 except: import simplejson as json
+import xbmc
 
 SITE_IDENTIFIER = 'themoviedb_org'
 SITE_NAME = '[COLOR orange]TheMovieDB[/COLOR]'
@@ -143,7 +144,6 @@ def showGenreTV():
 
     oInputParameterHandler = cInputParameterHandler()
     sUrl = oInputParameterHandler.getValue('siteUrl')
-
     result = grab.getUrl(sUrl)
 
     total = len(result)
@@ -276,9 +276,11 @@ def showMovies(sSearch = ''):
 
     oGui.setEndOfDirectory(view)
 
+
+# BUG HERE NO TERM PROVIDED SITCHING PAGES
 def showSeries(sSearch=''):
     oInputParameterHandler = cInputParameterHandler()
-
+    
     iPage = 1
     if (oInputParameterHandler.exist('page')):
         iPage = oInputParameterHandler.getValue('page')
@@ -299,7 +301,7 @@ def showSeries(sSearch=''):
             term = ''
 
         result = grab.getUrl(sUrl, iPage, term)
-
+    
     oGui = cGui()
 
     total = len(result)
@@ -368,6 +370,8 @@ def showSeries(sSearch=''):
                 oOutputParameterHandler.addParameter('sSearch', sSearch)
             oOutputParameterHandler.addParameter('siteUrl', sUrl)
             oOutputParameterHandler.addParameter('page', iNextPage)
+            if (oInputParameterHandler.exist('genre')):
+                oOutputParameterHandler.addParameter('genre', oInputParameterHandler.getValue('genre'))
             oGui.addNext(SITE_IDENTIFIER, 'showSeries', '[COLOR teal]Page ' + str(iNextPage) + ' >>>[/COLOR]', oOutputParameterHandler)
 
     #test pr chnagement mode

--- a/plugin.video.vstream/resources/sites/themoviedb_org.py
+++ b/plugin.video.vstream/resources/sites/themoviedb_org.py
@@ -14,7 +14,6 @@ from resources.lib.tmdb import cTMDb
 
 try:    import json
 except: import simplejson as json
-import xbmc
 
 SITE_IDENTIFIER = 'themoviedb_org'
 SITE_NAME = '[COLOR orange]TheMovieDB[/COLOR]'
@@ -277,7 +276,7 @@ def showMovies(sSearch = ''):
     oGui.setEndOfDirectory(view)
 
 
-# BUG HERE NO TERM PROVIDED SITCHING PAGES
+
 def showSeries(sSearch=''):
     oInputParameterHandler = cInputParameterHandler()
     


### PR DESCRIPTION
Voir  #1945

Réinjection du critère de recherche lors du switching de pages
Fix: Recherche Visuelle -> Séries ( Genres ) 