### PR TITLE
Add attribute VSupdatesearch to class empty()

### DIFF
--- a/plugin.video.vstream/resources/lib/comaddon.py
+++ b/plugin.video.vstream/resources/lib/comaddon.py
@@ -130,7 +130,9 @@ class empty():
 
     def VSclose(self, dialog):
         pass
-
+    
+    def VSupdatesearch(self,dialog, total, text=''):
+        pass
 
 class progress(xbmcgui.DialogProgress):
 


### PR DESCRIPTION
In remote http:8080, I have an error when searching, I attach the modification by this way.

Below is the log to better understand.

21:14:26.602 T:1911132160  NOTICE: starting upnp client
21:14:26.675 T:1911132160  NOTICE: starting upnp server
21:14:26.687 T:1911132160  NOTICE: starting upnp controller
21:14:26.688 T:1911132160  NOTICE: starting upnp renderer
21:14:26.707 T:1577374464  NOTICE: ES: Starting UDP Event server on port 9777
21:14:26.707 T:1577374464  NOTICE: UDP: Listening on port 9777 (ipv6 : true)
21:14:26.708 T:1911132160   ERROR: JSONRPC Server: Failed to connect to sdpd
21:14:28.121 T:1497621248 WARNING: CPlayerCoreFactory::GetPlayer(Freebox Player): no such player: Freebox Player
21:14:29.619 T:1487307520 WARNING: SetMenuLanguage - TV menu language set to unknown value 'kor'
21:14:41.254 T:1426060032  NOTICE: call load methode
21:14:43.912 T:1451225856  NOTICE: Previous line repeats 1 times.
21:14:43.912 T:1451225856 WARNING: CPythonInvoker(4, /home/pi/.kodi/addons/plugin.video.vstream/default.py): the python script "/home/pi/.kodi/addons/plugin.video.vstream/default.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon7xbmcgui6DialogE,N9XBMCAddon9xbmcaddon5AddonE
21:14:44.093 T:1426060032 WARNING: CPythonInvoker(3, /home/pi/.kodi/addons/plugin.video.vstream/default.py): the python script "/home/pi/.kodi/addons/plugin.video.vstream/default.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon9xbmcaddon5AddonE,N9XBMCAddon7xbmcgui6DialogE
21:14:52.124 T:1426060032  NOTICE: load site cHome and call function showSearchText
21:14:57.928 T:1426060032 WARNING: Attempt to use invalid handle 3
21:14:58.036 T:1426060032 WARNING: Previous line repeats 4 times.
21:14:58.037 T:1426060032 WARNING: CPythonInvoker(5, /home/pi/.kodi/addons/plugin.video.vstream/default.py): the python script "/home/pi/.kodi/addons/plugin.video.vstream/default.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon9xbmcaddon5AddonE,N9XBMCAddon7xbmcgui6DialogE
21:15:02.158 T:1426060032  NOTICE: load site globalSearch and call function showSearch
21:15:11.512 T:1426060032  NOTICE: return empty
21:15:11.524 T:1426060032   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.AttributeError'>
                                            Error Contents: empty instance has no attribute 'VSupdatesearch'
                                            Traceback (most recent call last):
                                              File "/home/pi/.kodi/addons/plugin.video.vstream/default.py", line 289, in <module>
                                                main()
                                              File "/home/pi/.kodi/addons/plugin.video.vstream/default.py", line 24, in __init__
                                                self.parseUrl()
                                              File "/home/pi/.kodi/addons/plugin.video.vstream/default.py", line 96, in parseUrl
                                                searchGlobal()
                                              File "/home/pi/.kodi/addons/plugin.video.vstream/default.py", line 233, in searchGlobal
                                                progress_.VSupdatesearch(progress_, total, 'plugin...')
                                            AttributeError: empty instance has no attribute 'VSupdatesearch'