### PR TITLE
Update livetv.py - Icone Sport

### DIFF
--- a/plugin.video.vstream/resources/sites/livetv.py
+++ b/plugin.video.vstream/resources/sites/livetv.py
@@ -136,7 +136,7 @@ def showMovies(sSearch = ''):#affiche les catégories qui on des lives'
             oOutputParameterHandler.addParameter('sMovieTitle', sTitle)
             oOutputParameterHandler.addParameter('sThumb', sThumb)
 
-            oGui.addMovie(SITE_IDENTIFIER, 'showMovies2', sTitle, '', sThumb, sDesc, oOutputParameterHandler)
+            oGui.addDir(SITE_IDENTIFIER, 'showMovies2', sTitle, 'sport.png', oOutputParameterHandler)
 
         progress_.VSclose(progress_)
 
@@ -203,7 +203,7 @@ def showMovies2(sSearch = ''): #affiche les matchs en direct depuis la section s
             oOutputParameterHandler.addParameter('sMovieTitle2', sTitle2)
             oOutputParameterHandler.addParameter('sThumb', sThumb)
 
-            oGui.addMovie(SITE_IDENTIFIER, 'showMovies3', sTitle2, '', sThumb, sDesc, oOutputParameterHandler)
+            oGui.addDir(SITE_IDENTIFIER, 'showMovies3', sTitle2, 'sport.png', oOutputParameterHandler)
 
         progress_.VSclose(progress_)
 
@@ -256,7 +256,7 @@ def showMovies3(sSearch = ''): #affiche les videos disponible du live
             oOutputParameterHandler.addParameter('sMovieTitle2', sTitle)
             oOutputParameterHandler.addParameter('sThumb', sThumb)
 
-            oGui.addMovie(SITE_IDENTIFIER, 'showHosters', sTitle, '', sThumb, sDesc, oOutputParameterHandler)
+            oGui.addDir(SITE_IDENTIFIER, 'showHosters', sTitle, 'sport.png', oOutputParameterHandler)
 
         progress_.VSclose(progress_)
 


### PR DESCRIPTION
Affiche l'icone "Sport" pour chaque catégorie au lieu d'afficher la pochette d'un film homonyme.