### PR TITLE
 Optimisation Affichage FanArt

### DIFF
--- a/plugin.video.vstream/resources/lib/gui/gui.py
+++ b/plugin.video.vstream/resources/lib/gui/gui.py
@@ -344,6 +344,8 @@ class cGui():
             sSiteUrl = oOutputParameterHandler.getValue('siteUrl')
             oGuiElement.setSiteUrl(sSiteUrl)
 
+        oGuiElement.setMeta(0)
+        
         oListItem = self.createListItem(oGuiElement)
         oListItem.setProperty("IsPlayable", "true")
         oListItem.setProperty("Video", "true")

--- a/plugin.video.vstream/resources/lib/gui/guiElement.py
+++ b/plugin.video.vstream/resources/lib/gui/guiElement.py
@@ -446,8 +446,15 @@ class cGuiElement:
         #sTitle=sTitle.replace('VF', '').replace('VOSTFR', '').replace('FR', '')
 
         #get_meta(self, media_type, name, imdb_id='', tmdb_id='', year='', overlay=6, update=False):
+        meta = self.getMeta()
+
+        # non media -> pas de fanart
+        if meta == 0 :
+            self.addItemProperties('fanart_image', '')
+            return
+			
         sType = '1'
-        sType = str(self.getMeta()).replace('1', 'movie').replace('2', 'tvshow')
+        sType = str(meta).replace('1', 'movie').replace('2', 'tvshow')
 
         if sType:
             from resources.lib.tmdb import cTMDb
@@ -532,9 +539,13 @@ class cGuiElement:
                 self.__TmdbId = meta['tvdb_id']
         except: pass
 
+        # Si fanart trouvé dans les meta alors on l'utilise, sinon on n'en met pas
         if meta['backdrop_url']:
             self.addItemProperties('fanart_image', meta['backdrop_url'])
             self.__sFanart = meta['backdrop_url']
+        else:
+            self.addItemProperties('fanart_image', '')
+
         # if meta['trailer_url']:
             # meta['trailer'] = meta['trailer'].replace(u'\u200e', '').replace(u'\u200f', '')
             # self.__sTrailerUrl = meta['trailer']
@@ -592,7 +603,7 @@ class cGuiElement:
         # - dateadded : string (Y-m-d h:m:s = 2009-04-05 23:16:04)
 
 
-        if self.getMeta() > 0 and self.getMetaAddon() == 'true':
+        if self.getMetaAddon() == 'true':
             self.getMetadonne()
         return self.__aItemValues
 

--- a/plugin.video.vstream/resources/sites/livetv.py
+++ b/plugin.video.vstream/resources/sites/livetv.py
@@ -86,7 +86,7 @@ def showGenres(): #affiche les clubs de foot
 
     oGui.setEndOfDirectory()
 
-def showMovies(sSearch = ''):#affiche les catégories qui on des lives'
+def showMovies(sSearch = ''):#affiche les catégories qui ont des lives
     oGui = cGui()
     if sSearch:
       sUrl = sSearch
@@ -115,26 +115,17 @@ def showMovies(sSearch = ''):#affiche les catégories qui on des lives'
             if progress_.iscanceled():
                 break
 
+            sUrl2 = aEntry[0]
+            sUrl2 = URL_MAIN + sUrl2
+
             sTitle = aEntry[1]
             sTitle = sTitle.decode("iso-8859-1", 'ignore')
             sTitle = cUtil().unescape(sTitle)
             sTitle = sTitle.encode("utf-8", 'ignore')
-            sUrl2 = aEntry[0]
-            sThumb = ''
-            #sLang = aEntry[3]
-            #sQual = aEntry[4]
-            sHoster = aEntry[2]
-            sDesc = ''
-
-            sTitle = sTitle.decode("iso-8859-1", 'ignore')
-            sTitle = sTitle.encode("utf-8", 'ignore')
-            sTitle = ('%s (%s)') % (sTitle, sHoster)
-            sUrl2 = URL_MAIN + sUrl2
 
             oOutputParameterHandler = cOutputParameterHandler()
             oOutputParameterHandler.addParameter('siteUrl2', sUrl2)
             oOutputParameterHandler.addParameter('sMovieTitle', sTitle)
-            oOutputParameterHandler.addParameter('sThumb', sThumb)
 
             oGui.addDir(SITE_IDENTIFIER, 'showMovies2', sTitle, 'sport.png', oOutputParameterHandler)
 


### PR DESCRIPTION
Ne pas chercher à afficher un fanart si le média n'est pas un film ou une série.
Si pas de fanart trouvé pour un média, ne pas en afficher : pas même celui par défaut de l'addon, laisser le skin afficher son background.