### PR TITLE
Update default.py - Modification des settings en dynamique

### DIFF
--- a/plugin.video.vstream/default.py
+++ b/plugin.video.vstream/default.py
@@ -40,6 +40,18 @@ class main:
             VSlog('call load methode')
             sFunction = "load"
 
+        if (sFunction=='setSetting'):
+            if (oInputParameterHandler.exist('id')):
+                id = oInputParameterHandler.getValue('id')
+            else: return
+
+            if (oInputParameterHandler.exist('value')):
+                value = oInputParameterHandler.getValue('value')
+            else: return
+
+            setSetting(id, value)
+            return
+
         if (sFunction=='DoNothing'):
             return
 
@@ -142,6 +154,16 @@ class main:
                 import traceback
                 traceback.print_exc()
                 return
+
+def setSetting(id, value):
+    addons = addon()
+    setting = addons.getSetting(id)
+
+    # Si le parametre existe, on autorise la modification
+    if (setting != '') :
+        addons.setSetting(id, value)
+        return True
+    return False
 
 def isHosterGui(sSiteName, sFunction):
     if (sSiteName == 'cHosterGui'):


### PR DESCRIPTION
Modification des settings par URL.

Permet une meilleure intégration de Vstream dans d'autre addon, par la modification des settings en dynamique.

Exemples d'utilisation : 

- Désactiver une source
plugin.video.vstream,function=setSetting&id=plugin_kepliz_com&value=false

- Activer les Métadonnées
plugin.video.vstream,function=setSetting&id=meta-view&value=true

- Changer l'URL de ZT
plugin.video.vstream,function=setSetting&id=ZT&value=https://vwww.annuaire-telechargement.com

etc...