### PR TITLE
FanArt pour les integrales de films

### DIFF
--- a/plugin.video.vstream/resources/lib/gui/gui.py
+++ b/plugin.video.vstream/resources/lib/gui/gui.py
@@ -51,6 +51,27 @@ class cGui():
 
         self.addFolder(oGuiElement, oOutputParameterHandler)
 
+	# Coffret et integrale de films
+    def addMoviePack(self, sId, sFunction, sLabel, sIcon, sThumbnail, sDesc, oOutputParameterHandler = ''):
+        cGui.CONTENT = "movies"
+        oGuiElement = cGuiElement()
+        oGuiElement.setSiteName(sId)
+        oGuiElement.setFunction(sFunction)
+        oGuiElement.setTitle(sLabel)
+        oGuiElement.setIcon(sIcon)
+        oGuiElement.setThumbnail(sThumbnail)
+        oGuiElement.setPoster(sThumbnail)
+        oGuiElement.setMeta(3)
+        oGuiElement.setDescription(sDesc)
+        #oGuiElement.setMovieFanart()
+        oGuiElement.setCat(1)
+
+        if oOutputParameterHandler.getValue('sMovieTitle'):
+            sTitle = oOutputParameterHandler.getValue('sMovieTitle')
+            oGuiElement.setFileName(sTitle)
+
+        self.addFolder(oGuiElement, oOutputParameterHandler)
+
 
     def addTV(self, sId, sFunction, sLabel, sIcon, sThumbnail, sDesc, oOutputParameterHandler = ''):
         cGui.CONTENT = "tvshows"

--- a/plugin.video.vstream/resources/lib/gui/guiElement.py
+++ b/plugin.video.vstream/resources/lib/gui/guiElement.py
@@ -441,25 +441,36 @@ class cGuiElement:
 
     def getMetadonne(self):
 
+        sTitle = self.__sFileName
+
         #sTitle = self.__sTitle.decode('latin-1').encode("utf-8")
         #sTitle=re.sub(r'\[.*\]|\(.*\)', r'', str(self.__sFileName))
         #sTitle=sTitle.replace('VF', '').replace('VOSTFR', '').replace('FR', '')
 
         #get_meta(self, media_type, name, imdb_id='', tmdb_id='', year='', overlay=6, update=False):
-        meta = self.getMeta()
+        metaType = self.getMeta()
 
         # non media -> pas de fanart
-        if meta == 0 :
+        if metaType == 0 :
             self.addItemProperties('fanart_image', '')
             return
 			
+        # Integrale de films, on nettoie le titre pour la recherche
+        if metaType == 3 :
+            sTitle=self.__sFileName.replace('integrale', '')
+            sTitle=sTitle.replace('Les 2 films', '')
+            sTitle=sTitle.replace('trilogie', '')
+            sTitle=sTitle.replace('trilogy', '')
+            sTitle=sTitle.replace('quadrilogie', '')
+            sTitle=sTitle.replace('pentalogie', '')
+
         sType = '1'
-        sType = str(meta).replace('1', 'movie').replace('2', 'tvshow')
+        sType = str(metaType).replace('1', 'movie').replace('2', 'tvshow').replace('3', 'movie')
 
         if sType:
             from resources.lib.tmdb import cTMDb
             grab = cTMDb()
-            args = (sType, self.__sFileName)
+            args = (sType, sTitle)
             kwargs = {}
             if (self.__ImdbId):
                 kwargs['imdb_id'] = self.__ImdbId
@@ -549,9 +560,12 @@ class cGuiElement:
         # if meta['trailer_url']:
             # meta['trailer'] = meta['trailer'].replace(u'\u200e', '').replace(u'\u200f', '')
             # self.__sTrailerUrl = meta['trailer']
-        if meta['cover_url']:
-            self.__sThumbnail = meta['cover_url']
-            self.__sPoster = meta['cover_url']
+
+        # Pas de changement de cover pour les coffrets de films
+        if metaType != 3 :
+            if meta['cover_url']:
+                self.__sThumbnail = meta['cover_url']
+                self.__sPoster = meta['cover_url']
         return
 
     def getItemValues(self):

--- a/plugin.video.vstream/resources/settings.xml
+++ b/plugin.video.vstream/resources/settings.xml
@@ -59,7 +59,7 @@
         <setting type="sep"/>
 
 	    <!--parametre qui enregistre l'url actuel de zt -->
-        <setting id="ZT" type="text" label="" default="" visible="false"/>
+        <setting id="URL_zone_telechargement_ws" type="text" label="" default="" visible="false"/>
 
         <!--parametre qui enregistre le token alldebrid pour extreme download -->
         <setting id="token_alldebrid" type="text" label="Token Alldebrid" default="" visible="false"/>

--- a/plugin.video.vstream/resources/settings.xml
+++ b/plugin.video.vstream/resources/settings.xml
@@ -59,7 +59,7 @@
         <setting type="sep"/>
 
 	    <!--parametre qui enregistre l'url actuel de zt -->
-        <setting id="URL_zone_telechargement_ws" type="text" label="" default="" visible="false"/>
+        <setting id="ZT" type="text" label="" default="" visible="false"/>
 
         <!--parametre qui enregistre le token alldebrid pour extreme download -->
         <setting id="token_alldebrid" type="text" label="Token Alldebrid" default="" visible="false"/>

--- a/plugin.video.vstream/resources/sites/zone_telechargement_ws.py
+++ b/plugin.video.vstream/resources/sites/zone_telechargement_ws.py
@@ -451,6 +451,8 @@ def showMovies(sSearch = ''):
                 oGui.addTV(SITE_IDENTIFIER, 'showSeriesLinks', sDisplayTitle, '', sThumb, '', oOutputParameterHandler)
             elif 'series' in sUrl2 or 'animes' in sUrl2:
                 oGui.addTV(SITE_IDENTIFIER, 'showSeriesLinks', sDisplayTitle, '', sThumb, '', oOutputParameterHandler)
+            elif 'collection' in sUrl or 'integrale' in sUrl:
+                oGui.addMoviePack(SITE_IDENTIFIER, 'showMoviesLinks', sDisplayTitle, '', sThumb, '', oOutputParameterHandler)
             else:
                 oGui.addMovie(SITE_IDENTIFIER, 'showMoviesLinks', sDisplayTitle, '', sThumb, '', oOutputParameterHandler)
 


### PR DESCRIPTION
Pour les integrales de films : 
- enlever le terme "integrale" pour trouver le fanArt et le résumé (du premier film)
- mais laisser la pochette spécifique du site (sinon pochette du premier film de la saga)

Utilisation avec ZT.