### PR TITLE
Skstream - retrait de la date des liens

### DIFF
--- a/plugin.video.vstream/resources/sites/skstream_co.py
+++ b/plugin.video.vstream/resources/sites/skstream_co.py
@@ -349,21 +349,16 @@ def showHosters():
     sHtmlContent = oRequestHandler.request()
 
     oParser = cParser()
-    sPattern = "<div class=\"date_server\">([^<]+)<|href='([^']+)' (?:|target=\"_blank\" )class=\"a_server"
+    sPattern = "href='([^']+)' (?:|target=\"_blank\" )class=\"a_server"
 
     aResult = oParser.parse(sHtmlContent, sPattern)
 
     if (aResult[0] == True):
-        for aEntry in aResult[1]:
-
-            if aEntry[0]:
-                oGui.addText(SITE_IDENTIFIER, '[COLOR red]' + aEntry[0] + '[/COLOR]')
-            else:
-                sHosterUrl = aEntry[1]
-                oHoster = cHosterGui().checkHoster(sHosterUrl)
-                if (oHoster != False):
-                    oHoster.setDisplayName(sMovieTitle)
-                    oHoster.setFileName(sMovieTitle)
-                    cHosterGui().showHoster(oGui, oHoster, sHosterUrl, sThumb)
+        for sHosterUrl in aResult[1]:
+            oHoster = cHosterGui().checkHoster(sHosterUrl)
+            if (oHoster != False):
+                oHoster.setDisplayName(sMovieTitle)
+                oHoster.setFileName(sMovieTitle)
+                cHosterGui().showHoster(oGui, oHoster, sHosterUrl, sThumb)
 
     oGui.setEndOfDirectory()


### PR DESCRIPTION
Retrait de la date proposée au dessus des liens, qui n'apporte pas de fonctionnalité intéressante aux utilisateurs.