### PR TITLE
Integrate a DNS resolver from French Data Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installez le zip du repository, pour avoir les mises à jour automatiques ou ins
 
 [![images](https://img.shields.io/badge/T%C3%A9l%C3%A9charger-Repository-blue.svg?style=for-the-badge)](https://github.com/Kodi-vStream/venom-xbmc-addons/releases/tag/0.0.3)
 
-Suite à des bloquages plutôt agressif des FAI, il peut être utile pour vous de changer vos DNS, plus d'infos par exemple sur ce lien: `https://www.numerama.com/tech/208908-comment-changer-ses-dns-ubuntu-macos-windows.html`
+Suite à des blocages plutôt agressif des FAI, il peut être utile pour vous de changer vos DNS, plus d'infos par exemple sur ce lien: `https://www.numerama.com/tech/208908-comment-changer-ses-dns-ubuntu-macos-windows.html`
 
 ## Contribuer!
 

--- a/plugin.video.vstream/addon.xml
+++ b/plugin.video.vstream/addon.xml
@@ -5,9 +5,10 @@
         <import addon="script.module.simplejson" version="3.3.0"/>
         <import addon="script.module.urlresolver" optional="true"/>
         <import addon="script.module.requests" version="2.9.1"/>
-	    <import addon="script.video.F4mProxy" optional="true"/>
+        <import addon="script.video.F4mProxy" optional="true"/>
+        <import addon="script.module.dnspython" optional="true"/>
         <import addon="repository.vstream" version="0.0.3"/>
-<!-- Pour le DEBUG        <import addon="script.module.pydevd" version="4.4.0"/> -->    
+<!-- Pour le DEBUG        <import addon="script.module.pydevd" version="4.4.0"/> -->
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>

--- a/plugin.video.vstream/resources/language/English/strings.po
+++ b/plugin.video.vstream/resources/language/English/strings.po
@@ -1051,3 +1051,7 @@ msgstr ""
 msgctxt "#30469"
 msgid "Hoster Direct"
 msgstr ""
+
+msgctxt "#30470"
+msgid "Addon dnspython missing"
+msgstr ""

--- a/plugin.video.vstream/resources/language/French/strings.po
+++ b/plugin.video.vstream/resources/language/French/strings.po
@@ -1050,4 +1050,8 @@ msgstr "Minute"
 
 msgctxt "#30469"
 msgid "Hoster Direct"
-msgstr ""
+msgstr "Hoster Direct"
+
+msgctxt "#30470"
+msgid "Addon dnspython missing"
+msgstr "Addon dnspython manquant"


### PR DESCRIPTION
Bonjour,

Je propose d'integrer la lib dns-resolver et d'utiliser les résolveurs DNS ouverts de FDN: https://www.fdn.fr/actions/dns/

J'ai testé avec les sources hds_stream et k_streaming qui sont bloqués chez moi.

Le dns resolver est activé que si on a un soucis lors d'une requête avec cRequestHandler

**Avant:**
05:26:36.511 T:49892  NOTICE: 	[PLUGIN] vStream: Load Search: hds_stream
05:26:36.603 T:49892  NOTICE: 	[PLUGIN] vStream: Erreur: Connection Failed ([Errno 11001] getaddrinfo failed),https:// www 1.k-streaming .co/recherche/suits
05:26:36.609 T:49892  NOTICE: 	[PLUGIN] vStream: Load Search: k_streaming
05:26:36.655 T:49892  NOTICE: 	[PLUGIN] vStream: Erreur: Connection Failed ([Errno 11001] getaddrinfo failed),https:// hdss. to/?s=suits

**Après:**
05:02:36.127 T:52116  NOTICE: 	[PLUGIN] vStream: Load Search: hds_stream
05:02:36.322 T:52116  NOTICE: 	[PLUGIN] vStream: new_getaddrinfo found host 104. 31.94.107
05:02:36.538 T:52116  NOTICE: 	[PLUGIN] vStream: Load Search: k_streaming
05:02:36.728 T:52116  NOTICE: 	[PLUGIN] vStream: new_getaddrinfo found host 104. 28.21.210
