### PR TITLE
Update zustream.py

### DIFF
--- a/plugin.video.vstream/resources/sites/zustream.py
+++ b/plugin.video.vstream/resources/sites/zustream.py
@@ -7,8 +7,9 @@ from resources.lib.gui.gui import cGui
 from resources.lib.handler.inputParameterHandler import cInputParameterHandler
 from resources.lib.handler.outputParameterHandler import cOutputParameterHandler
 from resources.lib.handler.requestHandler import cRequestHandler
-from resources.lib.comaddon import progress
+from resources.lib.comaddon import progress, VSlog
 from resources.lib.parser import cParser
+from resources.lib.packer import cPacker
 from resources.lib.util import cUtil
 import re
 
@@ -379,17 +380,21 @@ def showHosters():
     oRequest.addParametersLine(pdata)
 
     sHtmlContent = oRequest.request()
+    oParser = cParser()
 
     #1
     sPattern = '(?:<iframe|<IFRAME).+?(?:src|SRC)=(?:\'|")(.+?)(?:\'|")'
     aResult1 = re.findall(sPattern, sHtmlContent)
+    VSlog(aResult1)
 
     #2
     sPattern = '<a href="([^"]+)">'
     aResult2 = re.findall(sPattern, sHtmlContent)
+    VSlog(aResult2)
 
     #fusion
     aResult = aResult1 + aResult2
+    VSlog(aResult)
 
     if (aResult):
         for aEntry in aResult:
@@ -397,6 +402,31 @@ def showHosters():
             sHosterUrl = aEntry
             if 'zustreamv2/viplayer' in sHosterUrl:
                 return
+            
+            #Attention c'est que pour Gounlimited il y a la présence d'un autre hoster
+            #derrière la redirection qui s'appelle Streamtape !!!
+            
+            if 're.zu-lien.com' in sHosterUrl:
+                UA = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:56.0) Gecko/20100101 Firefox/56.0'
+                oRequestHandler = cRequestHandler(sHosterUrl)
+                oRequestHandler.addHeaderEntry('User-Agent', UA)
+                oRequestHandler.addHeaderEntry('Referer', 'https://re.zu-lien.com')
+                sHtmlContent2 = oRequestHandler.request()
+                #VSlog(sHtmlContent2)
+                sPattern = '(eval\(function\(p,a,c,k,e(?:.|\s)+?\))<\/script>'
+                aResult = oParser.parse(sHtmlContent2, sPattern)
+                if (aResult[0] == True):
+                    sHtmlContent = cPacker().unpack(aResult[1][0])
+                    #VSlog(sHtmlContent)
+                    sPattern = 'src:"([^"]+)"'
+                    aResult = oParser.parse(sHtmlContent, sPattern)
+                    if (aResult[0] == True):
+                        sHosterUrl = aResult[1][0]
+                        oHoster = cHosterGui().checkHoster(sHosterUrl)
+                        if (oHoster != False):
+                            oHoster.setDisplayName(sMovieTitle)
+                            oHoster.setFileName(sMovieTitle)
+                            cHosterGui().showHoster(oGui, oHoster, sHosterUrl, sThumb)
 
             oHoster = cHosterGui().checkHoster(sHosterUrl)
             if (oHoster != False):


### PR DESCRIPTION
Présence d'une redirection dans la partie hoster qui redirige vers 2 hébergeur 
Gounlimited et Streamtape 
Seul Gounlimited est fait Streamtape non car le fichier hoster n'est pas fait (enfin je crois ) 
et qui contient du code de recaptcha donc je ne sais pas si on peut le faire ou pas 
Merci