### PR TITLE
Update player.py

### DIFF
--- a/plugin.video.vstream/resources/lib/player.py
+++ b/plugin.video.vstream/resources/lib/player.py
@@ -114,12 +114,15 @@ class cPlayer(xbmc.Player):
 
         #Attend que le lecteur demarre, avec un max de 20s
         if xbmc.getInfoLabel('system.buildversion')[0:2] >= '19':
-            xrange = range
-
-        for _ in xrange(20):
-            if self.playBackEventReceived:
-                break
-            xbmc.sleep(1000)
+            for _ in range(20):
+                if self.playBackEventReceived:
+                    break
+                xbmc.sleep(1000)
+        else:
+            for _ in xrange(20):
+                if self.playBackEventReceived:
+                    break
+                xbmc.sleep(1000)
 
         #active/desactive les sous titres suivant l'option choisie dans la config
         if (self.SubtitleActive):


### PR DESCRIPTION
https://github.com/Kodi-vStream/venom-xbmc-addons/issues/3029#issuecomment-689251184
je ne souhaite pas vraiment faire un pr
c'est juste pour indiquer que 

```
116 if xbmc.getInfoLabel('system.buildversion')[0:2] >= '19':
117          xrange = range
```
est la cause qui entraine que l'on a à chaque fois file ''erreur fichier introuvable' alors que la video se lance bien

peu être peu on utiliser seulement
for _ in range(20): pour py2 et py3 mais je ne suis pas assez calé pour entrevoir les vrais conséquences
le pr marche évidement pour p2 et  devrait marcher pour p3 
mais c'est pas forcement le code le plus finos