### PR TITLE
Update time2watch.py

### DIFF
--- a/plugin.video.vstream/resources/sites/time2watch.py
+++ b/plugin.video.vstream/resources/sites/time2watch.py
@@ -451,7 +451,7 @@ def showSaisonEpisodes():
 
     url = re.search("document\.getElementById\(\'openlink_\'\+n\).href = '(.+?)';", sHtmlContent).group(1)
     oParser = cParser()
-    sPattern = '<span style="margin-left: 20px;">(.+?)</span>|<span style="margin-left: 35px;">(.+?)<.+?<span class="fa arrow">|<i class="fa fa-download fa-fw">.+?<b>(.+?)</b>.+?var hash_.+?= "(.+?)"'
+    sPattern = '<span style="margin-left: 20px;">(.+?)</span>|<span style="margin-left: 35px;">(.+?)<.+?<span class="fa arrow">|setfatherasseen.+?<i class="fa fa-download fa-fw">.+?<b>(.+?)</b>.+?var hash_.+?= "(.+?)"'
     aResult = oParser.parse(sHtmlContent, sPattern)
 
     if (aResult[0] == True):


### PR DESCRIPTION

BUG : il y a un lien / un dossier présent dans les menus hoster de vstream qui n'est pas valide 
et qui doit être exclu en générale c'est le lien VOSTFR 1080p
dans le pattern je suis partis du principe que l'on peu filtrer les résultats car 
la chaîne setfatherasseen "semble" présente pour les
pour les liens valident (quand il s'agit de série)

mais j'aurais voulu plutôt filtrer le résultats en utilisant la chaine
'display: none' ce qui serait bcp plus fiable et logique 
vu que ce sont les liens qui ne sont pas visibles qui ne sont pas valident

de plus
le jour ou cette chaîne ne sera plus utilisée ou qu'elle changera 
il n'y aura plus rien du tout à voir !!!
alors que là on à un lien en trop qui apparaît dans vstream
 (ce qui je pense n'est pas si dramatique que cela)
alors je sais pas si c'est raisonnable de valider ce pr
blabla blabla^^
