### PR TITLE
Remplacer fonction obsolete

### DIFF
--- a/plugin.video.vstream/resources/lib/comaddon.py
+++ b/plugin.video.vstream/resources/lib/comaddon.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # https://github.com/Kodi-vStream/venom-xbmc-addons
 
-import xbmcaddon, xbmcgui, xbmc
+import xbmcaddon, xbmcgui, xbmc, xbmcvfs 
 
 """System d'importation
 

--- a/plugin.video.vstream/resources/lib/db.py
+++ b/plugin.video.vstream/resources/lib/db.py
@@ -5,7 +5,7 @@ import xbmcvfs
 
 from resources.lib.handler.inputParameterHandler import cInputParameterHandler
 from resources.lib.util import QuotePlus, Unquote
-from resources.lib.comaddon import dialog, addon, VSlog, xbmc
+from resources.lib.comaddon import dialog, addon, VSlog, VSPath
 
 SITE_IDENTIFIER = 'cDb'
 SITE_NAME = 'DB'
@@ -17,15 +17,14 @@ except:
     from pysqlite2 import dbapi2 as sqlite
     VSlog('SQLITE 2 as DB engine for db')
 
-
 class cDb:
 
     DB = 'special://home/userdata/addon_data/plugin.video.vstream/vstream.db'
     # important seul xbmcvfs peux lire le special
     try:
-        REALDB = xbmc.translatePath(DB).decode('utf-8')
+        REALDB = VSPath(DB).decode('utf-8')
     except AttributeError:
-        REALDB = xbmc.translatePath(DB)
+        REALDB = VSPath(DB)
 
     def __init__(self):
 

--- a/plugin.video.vstream/resources/lib/download.py
+++ b/plugin.video.vstream/resources/lib/download.py
@@ -14,7 +14,7 @@ import xbmcvfs
 import xbmcgui
 import xbmc
 
-from resources.lib.comaddon import addon, dialog, progress, VSlog, VSupdate
+from resources.lib.comaddon import addon, dialog, progress, VSlog, VSupdate, VSPath
 from resources.lib.db import cDb
 from resources.lib.gui.gui import cGui
 from resources.lib.gui.guiElement import cGuiElement
@@ -623,14 +623,14 @@ class cDownload:
         if (sTitle != False and len(sTitle) > 0):
 
             # chemin de sauvegarde
-            sPath2 = xbmc.translatePath(self.ADDON.getSetting('download_folder'))
+            sPath2 = VSPath(self.ADDON.getSetting('download_folder'))
 
             dialog = xbmcgui.Dialog()
             sPath = dialog.browse(3, 'Downloadfolder', 'files', '', False, False, sPath2)
 
             if (sPath != ''):
                 self.ADDON.setSetting('download_folder', sPath)
-                sDownloadPath = xbmc.translatePath(sPath + '%s' % (sTitle))
+                sDownloadPath = VSPath(sPath + '%s' % (sTitle))
 
                 if xbmcvfs.exists(sDownloadPath):
                     self.DIALOG.VSinfo(self.ADDON.VSlang(30082), sTitle)

--- a/plugin.video.vstream/resources/lib/enregistrement.py
+++ b/plugin.video.vstream/resources/lib/enregistrement.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 from resources.lib.gui.gui import cGui
-from resources.lib.comaddon import progress, addon, xbmc, xbmcgui, VSlog, dialog
+from resources.lib.comaddon import progress, addon, xbmcgui, VSlog, dialog, VSPath
 import xbmcvfs, datetime, time, _strptime, os
 
 SITE_IDENTIFIER = 'Enregistrement'
@@ -11,10 +11,7 @@ class cEnregistremement:
     def programmation_enregistrement(self, sUrl):
         oGui = cGui()
         ADDON = addon()
-        if 'firstonetv' in sUrl or 'bouygtel' in sUrl or 'heroku' in sUrl:
-            sUrl = sUrl.replace('|Referer=', '" -headers "Referer:').replace('&User-Agent=Mozilla/5.0+(X11;+Linux+i686)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Ubuntu+Chromium/48.0.2564.116+Chrome/48.0.2564.116+Safari/537.36&X-Requested-With=ShockwaveFlash/28.0.0.137&Origin=https://www.firstonetv.live', '" -headers "User-Agent:Mozilla/5.0+(X11;+Linux+i686)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Ubuntu+Chromium/48.0.2564.116+Chrome/48.0.2564.116+Safari/537.36" -headers "X-Requested-With:ShockwaveFlash/28.0.0.137" -headers "Origin:https://www.firstonetv.live" -sn -c:v copy -c:a copy')
-            header = '-fflags +genpts+igndts -y -i "' + sUrl
-        elif '.m3u8' in sUrl:
+        if '.m3u8' in sUrl:
             header = '-fflags +genpts+igndts -y -i "' + sUrl + '"'
         else:
             header = '-re -reconnect 1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 4294 -timeout 2000000000 -f mpegts -re -flags +global_header -fflags +genpts+igndts -y -i "' + sUrl +'" -headers "User-Agent: Mozilla/5.0+(X11;+Linux+i686)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Ubuntu+Chromium/48.0.2564.116+Chrome/48.0.2564.116+Safari/537.36" -sn -c:v libx264 -c:a copy -map 0 -segment_format mpegts -segment_time -1'
@@ -35,7 +32,7 @@ class cEnregistremement:
         timedelta = datetime.timedelta(minutes = int(marge))
         durer = durer + timedelta
 
-        realPath = xbmc.translatePath(pathEnregistrement + '/' + str(heureFichier) + '.py').replace('\\', '\\\\')
+        realPath = VSPath(pathEnregistrement + '/' + str(heureFichier) + '.py').replace('\\', '\\\\')
 
         f = xbmcvfs.File(realPath, 'w')
         read = f.write('''#-*- coding: utf-8 -*-

--- a/plugin.video.vstream/resources/lib/handler/requestHandler.py
+++ b/plugin.video.vstream/resources/lib/handler/requestHandler.py
@@ -14,7 +14,7 @@ except ImportError:  # Python 3
 import xbmc
 
 from resources.lib.util import urlEncode
-from resources.lib.comaddon import addon, dialog, VSlog
+from resources.lib.comaddon import addon, dialog, VSlog, VSPath
 
 
 class cRequestHandler:
@@ -259,7 +259,7 @@ class cRequestHandler:
             import sys
             import dns.resolver
 
-            path = xbmc.translatePath('special://home/addons/script.module.dnspython/lib/').decode('utf-8')
+            path = VSPath('special://home/addons/script.module.dnspython/lib/').decode('utf-8')
             if path not in sys.path:
                 sys.path.append(path)
             host = args[0]

--- a/plugin.video.vstream/resources/lib/runscript.py
+++ b/plugin.video.vstream/resources/lib/runscript.py
@@ -2,7 +2,7 @@
 # vStream https://github.com/Kodi-vStream/venom-xbmc-addons
 
 # vstream = xbmcaddon.Addon('plugin.video.vstream')
-# sLibrary = xbmc.translatePath(vstream.getAddonInfo("path")).decode("utf-8")
+# sLibrary = VSPath(vstream.getAddonInfo("path")).decode("utf-8")
 # sys.path.append (sLibrary)
 
 try:  # Python 2
@@ -16,7 +16,7 @@ import sys
 import xbmc
 import xbmcgui
 
-from resources.lib.comaddon import addon, dialog, VSlog, window
+from resources.lib.comaddon import addon, dialog, VSlog, window, VSPath
 from resources.lib.util import urlEncode
 
 try:
@@ -155,9 +155,9 @@ class cClear:
                 cached_Cache = "special://home/userdata/addon_data/plugin.video.vstream/video_cache.db"
                 # important seul xbmcvfs peux lire le special
                 try:
-                    cached_Cache = xbmc.translatePath(cached_Cache).decode("utf-8")
+                    cached_Cache = VSPath(cached_Cache).decode("utf-8")
                 except AttributeError:
-                    cached_Cache = xbmc.translatePath(cached_Cache)
+                    cached_Cache = VSPath(cached_Cache)
                 
                 try:
                     db = sqlite.connect(cached_Cache)
@@ -180,9 +180,9 @@ class cClear:
             cached_DB = "special://home/userdata/addon_data/plugin.video.vstream/vstream.db"
             # important seul xbmcvfs peux lire le special
             try:
-                cached_DB = xbmc.translatePath(cached_DB).decode("utf-8")
+                cached_DB = VSPath(cached_DB).decode("utf-8")
             except AttributeError:
-                cached_DB = xbmc.translatePath(cached_DB)
+                cached_DB = VSPath(cached_DB)
 
             sql_drop = ""
 

--- a/plugin.video.vstream/resources/lib/stormwall.py
+++ b/plugin.video.vstream/resources/lib/stormwall.py
@@ -2,7 +2,7 @@ import re
 import os
 import xbmcaddon
 
-from resources.lib.comaddon import VSlog, xbmc
+from resources.lib.comaddon import VSlog, xbmc, VSPath
 from resources.lib.handler.requestHandler import cRequestHandler
 
 try:  # Python 2
@@ -11,7 +11,7 @@ try:  # Python 2
 except ImportError:  # Python 3
     import urllib.request as urllib2
 
-PathCache = xbmc.translatePath(xbmcaddon.Addon('plugin.video.vstream').getAddonInfo('profile'))
+PathCache = VSPath(xbmcaddon.Addon('plugin.video.vstream').getAddonInfo('profile'))
 UA = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:56.0) Gecko/20100101 Firefox/56.0'
 
 class Stormwall(object):

--- a/plugin.video.vstream/resources/lib/sucuri.py
+++ b/plugin.video.vstream/resources/lib/sucuri.py
@@ -10,14 +10,13 @@ except ImportError:  # Python 3
 import base64
 import os
 import re
-import xbmc
 import xbmcaddon
 import unicodedata
 
-from resources.lib.comaddon import VSlog
+from resources.lib.comaddon import VSlog, VSPath
 from resources.lib.util import urlEncode
 
-PathCache = xbmc.translatePath(xbmcaddon.Addon('plugin.video.vstream').getAddonInfo('profile'))
+PathCache = VSPath(xbmcaddon.Addon('plugin.video.vstream').getAddonInfo('profile'))
 UA = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; de-DE; rv:1.9.0.3) Gecko/2008092417 Firefox/3.0.3'
 
 

--- a/plugin.video.vstream/resources/lib/tmdb.py
+++ b/plugin.video.vstream/resources/lib/tmdb.py
@@ -12,7 +12,7 @@ import unicodedata
 import webbrowser
 
 from resources.lib.util import QuotePlus
-from resources.lib.comaddon import addon, dialog, VSlog, xbmc
+from resources.lib.comaddon import addon, dialog, VSlog, VSPath
 from resources.lib.handler.requestHandler import cRequestHandler
 
 try:
@@ -68,9 +68,9 @@ class cTMDb:
 
     # important seul xbmcvfs peux lire le special
     try:
-        REALCACHE = xbmc.translatePath(CACHE).decode('utf-8')
+        REALCACHE = VSPath(CACHE).decode('utf-8')
     except AttributeError:
-        REALCACHE = xbmc.translatePath(CACHE)
+        REALCACHE = VSPath(CACHE)
 
 
     def __init__(self, api_key='', debug=False, lang='fr'):

--- a/plugin.video.vstream/service.py
+++ b/plugin.video.vstream/service.py
@@ -3,7 +3,7 @@
 import subprocess
 import xbmcvfs
 from datetime import datetime
-from resources.lib.comaddon import addon, xbmc, VSlog
+from resources.lib.comaddon import addon, xbmc, VSlog, VSPath
 
 
 def service():
@@ -32,7 +32,7 @@ def service():
         hour = datetime.now().strftime('%d-%H-%M') + '.py'
         if hour in str(recordList):
             hour = path + '/' + hour
-            hour = xbmc.translatePath(hour)
+            hour = VSPath(hour)
             recordInProgress = True
             VSlog('python ' + hour)
             command = 'python ' + hour


### PR DESCRIPTION
Xbmc.translatePath() est remplacé par xbmcvfs.translatePath(). Pour éviter tout problèmes de compatibilité je passe par une fonction VSPath qui applique la fonction correspondant a la version.