### PR TITLE
Update zone_telechargement_ws.py

### DIFF
--- a/plugin.video.vstream/resources/sites/zone_telechargement_ws.py
+++ b/plugin.video.vstream/resources/sites/zone_telechargement_ws.py
@@ -435,6 +435,8 @@ def showMovies(sSearch=''):
                 oGui.addMisc(SITE_IDENTIFIER, 'showSeriesLinks', sTitle, '', sThumb, '', oOutputParameterHandler)
             elif 'collection' in sUrl or 'integrale' in sUrl:
                 oGui.addMoviePack(SITE_IDENTIFIER, 'showMoviesLinks', sDisplayTitle, '', sThumb, '', oOutputParameterHandler)
+            elif sSearch and ' Saison ' in sTitle:
+                oGui.addTV(SITE_IDENTIFIER, 'showSeriesLinks', sTitle, '', sThumb, '', oOutputParameterHandler)
             else:
                 oGui.addMovie(SITE_IDENTIFIER, 'showMoviesLinks', sTitle, '', sThumb, '', oOutputParameterHandler)
 


### PR DESCRIPTION
la recherche donne des erreurs quand c'est une serie sans doute parque la série est dirigée vers showMoviesLinks
ce n'est pas forcement la meilleurs solution