### PR TITLE
Fenetre information

### DIFF
--- a/plugin.video.vstream/resources/lib/gui/gui.py
+++ b/plugin.video.vstream/resources/lib/gui/gui.py
@@ -655,16 +655,19 @@ class cGui:
         sTest = '%s?site=%s' % (sPluginPath, sId)
 
         xbmc.executebuiltin('Container.Update(%s, replace)' % sTest)
-
+        
     def viewInfo(self):
-        from resources.lib.config import WindowsBoxes
+        if addon().getSetting('information-view') == "false":
+            from resources.lib.config import WindowsBoxes
 
-        oInputParameterHandler = cInputParameterHandler()
-        sCleanTitle = oInputParameterHandler.getValue('sFileName') if oInputParameterHandler.exist('sFileName') else xbmc.getInfoLabel('ListItem.Property(sCleanTitle)')
-        sMeta = oInputParameterHandler.getValue('sMeta') if oInputParameterHandler.exist('sMeta') else xbmc.getInfoLabel('ListItem.Property(sMeta)')
-        sYear = oInputParameterHandler.getValue('sYear') if oInputParameterHandler.exist('sYear') else xbmc.getInfoLabel('ListItem.Year')
+            oInputParameterHandler = cInputParameterHandler()
+            sCleanTitle = oInputParameterHandler.getValue('sFileName') if oInputParameterHandler.exist('sFileName') else xbmc.getInfoLabel('ListItem.Property(sCleanTitle)')
+            sMeta = oInputParameterHandler.getValue('sMeta') if oInputParameterHandler.exist('sMeta') else xbmc.getInfoLabel('ListItem.Property(sMeta)')
+            sYear = oInputParameterHandler.getValue('sYear') if oInputParameterHandler.exist('sYear') else xbmc.getInfoLabel('ListItem.Year')
 
-        WindowsBoxes(sCleanTitle, sCleanTitle, sMeta, sYear)
+            WindowsBoxes(sCleanTitle, sCleanTitle, sMeta, sYear)
+        else:
+            xbmc.executebuiltin('Action(Info)')
 
     def viewSimil(self):
         sPluginPath = cPluginHandler().getPluginPath()

--- a/plugin.video.vstream/resources/lib/tmdb.py
+++ b/plugin.video.vstream/resources/lib/tmdb.py
@@ -758,7 +758,7 @@ class cTMDb:
             crews = []
             
             if len(casts) > 0:
-                #licast = []
+                licast = []
                 if 'crew' in listCredits:
                     crews = listCredits['crew']
                 if len(crews)>0:
@@ -767,9 +767,9 @@ class cTMDb:
                     _meta['credits'] = "{u'cast': " + str(casts) + '}'
 #                 _meta['credits'] = "{u'cast': " + str(casts) + ", u'crew': "+str(crews) + "}"
 #                 _meta['credits'] = 'u\'cast\': ' + str(casts) + ''
-                #for cast in casts:
-                #    licast.append((cast['name'], cast['character'], self.poster + str(cast['profile_path']), str(cast['id'])))
-                #_meta['cast'] = licast
+                for cast in casts:
+                    licast.append((cast['name'], cast['character']))
+                _meta['cast'] = licast
 
             #if 'crew' in listCredits:
             if len(crews) > 0:

--- a/plugin.video.vstream/resources/settings.xml
+++ b/plugin.video.vstream/resources/settings.xml
@@ -37,6 +37,7 @@
         <setting id="accueil-view" type="number" label="30407" default="500" enable="eq(-2,true)"/>
         <setting id="movie-view" type="number" label="30404" default="500" enable="eq(-3,true)"/>
         <setting id="serie-view" type="number" label="30405" default="500" enable="eq(-4,true)"/>
+        <setting id="information-view" type="bool" label="Utiliser l'affichage du skin pour la fenetre information" default="false"/>
     </category>
 
     <!-- A propos/sources -->


### PR DESCRIPTION
Cette option permets de laisser l'utilisateur choisir entre la fenêtre par défaut de Vstream ou la fenêtre de son skin.

Dans l'exemple c'est avec le skin par défaut de Kodi 18, j'ai appelé la fenêtre depuis Ianime et toutes les informations s'affichent correctement.
![image](https://user-images.githubusercontent.com/24809312/103476402-86262c00-4db5-11eb-957d-e5a8656a30eb.png)
