### PR TITLE
Fix enchainement auto sur > 2 episodes

### DIFF
--- a/plugin.video.vstream/resources/lib/player.py
+++ b/plugin.video.vstream/resources/lib/player.py
@@ -125,12 +125,10 @@ class cPlayer(xbmc.Player):
         for _ in range(20):
             if self.playBackEventReceived:
                 break
-            if self.playBackStoppedEventReceived:
-                return False
             xbmc.sleep(1000)
 
         #active/desactive les sous titres suivant l'option choisie dans la config
-        if self.getAvailableSubtitleStreams():
+        if self.isPlaying and self.getAvailableSubtitleStreams():
             if (self.ADDON.getSetting('srt-view') == 'true'):
                 self.showSubtitles(True)
             else:


### PR DESCRIPTION
Salut et d'abord merci pour cette extension !
J'aime beaucoup la nouvelle fonctionnalité de lecture auto avec **NextUp**, mais je regardais une serie à épisode très courts ( < 5 min ) et seulement un épisode était automatiquement lancé, après plus rien (en laissant s'écouler le temps NextUp sans cliquer sur regarder maintenant).

Je me suis motivé et j'ai essayé de debug, je me suis rendu compte que le deuxième _player_ qui correspond au deuxième épisode n'envoyait jamais la notif à **NextUp** qui contient les infos de l'episode suivant, car il passait par le `return false` de la boucle de 20s et sortait de la fonction `run` (sans jamais envoyer la notif à NextUp).

Apparemment le 2 eme player recoit un _playBackStop_ mais je ne sais pas d'où il arrive (peut-etre de **NextUp** ?).

Avec cette modif ça marche mais est-ce qu'il n'y a pas mieux, qu'est-ce que vous en pensez ?