### PR TITLE
Remove unused column and fix history order

### DIFF
--- a/plugin.video.vstream/resources/lib/db.py
+++ b/plugin.video.vstream/resources/lib/db.py
@@ -65,9 +65,6 @@ class cDb(object):
                      "title TEXT, "\
                      "disp TEXT, "\
                      "icone TEXT, "\
-                     "isfolder TEXT, "\
-                     "level TEXT, "\
-                     "lastwatched TIMESTAMP "", "\
                      "UNIQUE(title)"\
                      ");"
         self.dbcur.execute(sql_create)
@@ -181,7 +178,7 @@ class cDb(object):
             pass
 
     def get_history(self):
-        sql_select = 'SELECT * FROM history'
+        sql_select = 'SELECT * FROM history ORDER BY addon_id DESC'
 
         try:
             self.dbcur.execute(sql_select)


### PR DESCRIPTION
:fr:
## Description
- Suppression de colonne non utilisé dans la table "history" de la DB.
- Tri de l'historique dans le bon ordre (on affiche les dernières recherches en haut et au plus on "descend", au plus c'est "vieux").

### Note
- Les suppressions des colonnes ne se fera pas pour les installations où le plugin est déjà installé... Seulement les nouvelles installation bénéficierons de ce "nettoyage".
- Il faudrait faire une tâche pour mettre à jour l'historique lorqu'on recherche quelque chose qu'on a déjà cherché. Cette tâche impliquera surement de récrer une colonne "timestamp".

:gb:
## Description
- Remove unused column in "history" table
- Sort correctly the history (most recent search are in the bottom and the oldest search are at the end)

### Notice
- Only new installation will benefit of the remove of unused table... Existing installation will not be clean.
- A new task needs to be created to update the history when we search something we already search. This task will probably re-create a column "timestamp".