### PR TITLE
Remove unused parameter

### DIFF
--- a/plugin.video.vstream/resources/lib/gui/hoster.py
+++ b/plugin.video.vstream/resources/lib/gui/hoster.py
@@ -357,7 +357,7 @@ class cHosterGui:
                     if len(aLink) > 2:
                         oPlayer.AddSubtitles(aLink[2])
 
-                    return oPlayer.run(oGuiElement, oHoster.getFileName(), aLink[1])
+                    return oPlayer.run(oGuiElement, aLink[1])
 
             oDialog.VSerror(self.ADDON.VSlang(30020))
             return

--- a/plugin.video.vstream/resources/lib/player.py
+++ b/plugin.video.vstream/resources/lib/player.py
@@ -81,7 +81,7 @@ class cPlayer(xbmc.Player):
         else:
             self.Subtitles_file.append(files)
 
-    def run(self, oGuiElement, sTitle, sUrl):
+    def run(self, oGuiElement, sUrl):
 
         # Lancement d'une vidéo sans avoir arreté la précedente
         self.tvShowTitle = oGuiElement.getItemValue('tvshowtitle')


### PR DESCRIPTION
Un paramètre (`sTitle`) dans une des méthodes (`run`) du Player n'est pas utilisé.