### PR TITLE
Phrase d'aide pour le template bug en commentaire

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,13 +9,13 @@ about: Créer un rapport de Bug
 
 **Votre system**
 - OS: [Windows, Android]
-- Appareil [nvidia shield, Ultra]
-- Version Kodi  [16.17.18]
-- Version Vstream
+- Appareil: [nvidia shield, Ultra]
+- Version Kodi: [16.17.18]
+- Version Vstream: [1.7.0]
 
 **Nous devons le reproduire**
 <!-- Pour cela il nous faut: -->
-- Nnom du site: 
+- Nom du site: 
 - Titre du fim/serie: 
 - Nom du host (openload/vidzi/...): 
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -5,26 +5,28 @@ about: Créer un rapport de Bug
 ---
 
 **Décrivez le bug**
-Une description claire et concise de ce qu'est le bug.
+<!-- Une description claire et concise de ce qu'est le bug. -->
 
 **Votre system**
- - OS: [Windows, Android]
--  Appareil [nvidia shield, Ultra]
- - Version Kodi  [16.17.18]
+- OS: [Windows, Android]
+- Appareil [nvidia shield, Ultra]
+- Version Kodi  [16.17.18]
 - Version Vstream
 
 **Nous devons le reproduire**
-Pour cela il nous faut:
-- Le nom du site
-- Le titre du fim/serie 
-- Le nom du host (openload/vidzi)
+<!-- Pour cela il nous faut: -->
+- Nnom du site: 
+- Titre du fim/serie: 
+- Nom du host (openload/vidzi/...): 
 
 **Log**
-L’accès un votre fichier log seras un plus. Pour savoir comment uploader votre log voir:
+<!-- 
+L’accès un votre fichier log seras un plus. Pour savoir comment uploader votre log voir: 
 https://kodi-vstream.github.io/docs/outils/
+-->
 
 **Image**
-Si votre soucis est visuel faite une capture d’écran.
+<!-- Si votre soucis est visuel faite une capture d’écran. -->
 
 **Plus**
-Ajoutez plus d'information sur le problème ici.
+<!-- Ajoutez plus d'information sur le problème ici. -->


### PR DESCRIPTION
J'ai mis les phrases d'explication en commentaire pour évite d'avoir ces informations "d'aide" dans les issues...   
Le but de ces phrases c'est d'aider la personne qui ouvre l'issue à savoir quoi mettre.  Cela ne nous donne aucune info une fois l'issue "ouverte"