### PR TITLE
Add filter to WatchedList - Ajout de filtre dans la liste des éléments en cours de visionnage

### DIFF
--- a/plugin.video.vstream/resources/lib/viewing.py
+++ b/plugin.video.vstream/resources/lib/viewing.py
@@ -57,6 +57,9 @@ class cViewing:
     def getViewing(self):
         oGui = cGui()
 
+        oInputParameterHandler = cInputParameterHandler()
+        catFilter = oInputParameterHandler.getValue('catFilter')
+
         with cDb() as DB:
             row = DB.get_viewing()
             if not row:
@@ -88,6 +91,9 @@ class cViewing:
                     cat = data['cat']
                     sSeason = data['season']
                     sTmdbId = data['tmdb_id'] if data['tmdb_id'] != '0' else None
+
+                    if catFilter is not False and cat != catFilter:
+                        continue
 
                     oOutputParameterHandler = cOutputParameterHandler()
                     oOutputParameterHandler.addParameter('siteUrl', siteurl)


### PR DESCRIPTION
Le but de cette PR est de permettre le tri des éléments dans la liste des éléments vu.

Cette PR permet d'utilise cette URL:
`plugin://plugin.video.vstream/?site=cViewing&function=getViewing&catFilter=1`
Permettant de limité les éléments listé.