### PR TITLE
Change the Content-type to respect FlareSolverr expectation

### DIFF
--- a/plugin.video.vstream/resources/sites/wiflix.py
+++ b/plugin.video.vstream/resources/sites/wiflix.py
@@ -237,7 +237,7 @@ def showSeries(sSearch=''):
         oRequest.addHeaderEntry('Referer', URL_MAIN)
         oRequest.addHeaderEntry('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
         oRequest.addHeaderEntry('Accept-Language', 'fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3')
-        oRequest.addHeaderEntry('Content-Type', 'application/x-www-form-urlencoded')
+        oRequest.addHeaderEntry('Content-Type', 'application/json')
         oRequest.addParametersLine(pdata)
         sHtmlContent = oRequest.request()
 


### PR DESCRIPTION
Bonjour, 

Tout d'abord merci pour le travail que vous effectuez. 

L'utilisation de Wiflix au travers de FlareSolverr (en mode container) tombait en erreur avec le message suivant : 'NoneType' object is not iterable'

Le header content-type n'etait pas celui qui est attendu par Flaresolverr, il doit contenir "application/json". (Voir la fin de la discussion https://github.com/FlareSolverr/FlareSolverr/discussions/1041).

J'ai fait la modification en local et ceci a permit de resoudre le soucis chez moi. (Raspberry pi pour vstream et FlareSolverr en mode container sur un linux).
J'ai testé la modification sur une installation de Kodi directement sur un PC, cette modification n'a pas eu d'effet de bord.

Je presume que cette modification devrait être effectué sur l'ensemble des sources qui nécessite FlareSolverr mais comme je n'ai pas la liste je pousse au moins celle-ci. 

Cordialement,  