### PR TITLE
Mise à jour eligol vers matele.ru

### DIFF
--- a/plugin.video.vstream/resources/sites.json
+++ b/plugin.video.vstream/resources/sites.json
@@ -92,7 +92,7 @@
         "elitegol": {
             "label": "Elitegol",
             "active": "True",
-            "url": "https://remontadatv.ru/",
+            "url": "https://matele.ru/",
             "site_info": "https://elitegol.lat/",
             "url_link": "plyz/3"
         },

--- a/plugin.video.vstream/resources/sites/elitegol.py
+++ b/plugin.video.vstream/resources/sites/elitegol.py
@@ -21,8 +21,8 @@ URL_LINK = siteManager().getDefaultProperty(SITE_IDENTIFIER, 'url_link')
 
 
 SPORT_SPORTS = (True, 'load')
-SPORT_GENRES = ('data.php', 'showGenres')  # FOOT
-SPORT_LIVE = ('data.php', 'showMovies')
+SPORT_GENRES = ('json.php', 'showGenres')  # FOOT
+SPORT_LIVE = ('json.php', 'showMovies')
 SPORT_TV = ('lecteur/', 'showTV')
 
 UA = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:56.0) Gecko/20100101 Firefox/56.0'


### PR DESCRIPTION
Le site eligol a changé de domaine et de chemin pour le json:

- remontadatv.ru -> matele.ru
- /data.php -> /json.php