### PR TITLE
Affichage de 3 des 4 liens pour chaque chaine de elitegol

### DIFF
--- a/plugin.video.vstream/resources/sites/elitegol.py
+++ b/plugin.video.vstream/resources/sites/elitegol.py
@@ -210,14 +210,16 @@ def showLink():
     sThumb = oInputParameterHandler.getValue('sThumb')
     sMovieTitle = oInputParameterHandler.getValue('sMovieTitle')
 
-    sHosterUrl = getHosterIframe(sUrl, sUrl)
-    if sHosterUrl:
-        sHosterUrl = sHosterUrl.strip()
-        oHoster = oHosterGui.checkHoster(sHosterUrl)
-        if oHoster:
-            oHoster.setDisplayName(sMovieTitle)
-            oHoster.setFileName(sMovieTitle)
-            oHosterGui.showHoster(oGui, oHoster, sHosterUrl, sThumb)
+    allUrls = [sUrl.replace('/3/', f'/{a}/') for a in [1,2,3,4]]
+    for sUrl in allUrls:
+        sHosterUrl = getHosterIframe(sUrl, sUrl)
+        if sHosterUrl:
+            sHosterUrl = sHosterUrl.strip()
+            oHoster = oHosterGui.checkHoster(sHosterUrl)
+            if oHoster:
+                oHoster.setDisplayName(sMovieTitle)
+                oHoster.setFileName(sMovieTitle)
+                oHosterGui.showHoster(oGui, oHoster, sHosterUrl, sThumb)
 
     oGui.setEndOfDirectory()
 
@@ -330,6 +332,12 @@ def getUrl(sHtmlContent, referer):
     aResult = re.findall(sPattern, sHtmlContent)
     if aResult:
         sHosterUrl = 'https://%s/hls/%s/live.m3u8' % (aResult[0][1], aResult[0][0])
+        return sHosterUrl + '|referer=' + referer
+
+    sPattern = "ThePlayerJS\('.+?','(.+?)'\);"
+    aResult = re.findall(sPattern, sHtmlContent)
+    if aResult:
+        sHosterUrl = 'https://mustardshock.com/player/%s' % aResult[0]
         return sHosterUrl + '|referer=' + referer
 
     return False


### PR DESCRIPTION
Pour toutes les chaines du site elitegol (comme par exemple https://matele.ru/live/sport/chaine/dazn+ligue+1/20/fr), il y a 4 onglets avec une vidéo dans chacun. 
Ce PR est pour gérer ces 4 onglets. 3 fonctionnent, mais pas le premier qui est sur https://mustardshock.com.
Je vais avoir besoin de votre aide, car je ne comprend comment fonctionne cHosterGui.checkHoster(), pour ajouter le support de mustardshock.
Merci d'intégrer cette modification pour au moins 3 des 4 liens pour le moment.