### PR TITLE
Réparation neymartv

### DIFF
--- a/plugin.video.vstream/resources/sites/elitegol.py
+++ b/plugin.video.vstream/resources/sites/elitegol.py
@@ -29,8 +29,7 @@ UA = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:56.0) Gecko/20100101 Firefox/5
 
 # chaines dans l'ordre d'affichage
 channels = {
-    1: ['bein Sports 1', 'https://images.beinsports.com/n43EXNeoR62GvZlWW2SXKuQi0GA=/788708-HD1.png'],
-    
+    1: ['bein Sports 1', 'https://prod-media.beinsports.com/image/85029984d97fda2dd293f3c7d6cf0c0d.png?ver=12-01-2025'],
     20: ['DAZN1', 'https://miguia.tv/channels/big_329@2x.png'],
 #    20: ['DAZN1\nC+ sport 2', 'https://miguia.tv/channels/big_329@2x.png'],
 #    20: ['Canal+ sport 2', 'https://upload.wikimedia.org/wikipedia/commons/4/40/Canal%2B_Sport_2_PL.png'],

--- a/plugin.video.vstream/resources/sites/neymartv.py
+++ b/plugin.video.vstream/resources/sites/neymartv.py
@@ -30,39 +30,39 @@ channels = [
     
 #    ['DAZN 1', ['https://poscitechs.lol/live/stream-106.php', 'https://images.beinsports.com/n43EXNeoR62GvZlWW2SXKuQi0GA=/788708-HD1.png']],
     
-    ['bein Sports 1', ['2023/01/bein-sports-1-full-hd-france.html', 'https://images.beinsports.com/n43EXNeoR62GvZlWW2SXKuQi0GA=/788708-HD1.png']],
-    ['bein Sports 2', ['2023/01/bein-sports-2-full-hd-france.html', 'https://images.beinsports.com/dZ2ESOsGlqynphSgs7MAGLwFAcg=/788711-HD2.png']],
-    ['bein Sports 3', ['2023/01/bein-sports-3-full-hd-france.html', 'https://images.beinsports.com/G4M9yQ3f4vbFINuKGIoeJQ6kF_I=/788712-HD3.png']],
+    ['bein Sports 1', ['2023/01/bein-sports-1-full-hd-france.html', 'https://prod-media.beinsports.com/image/85029984d97fda2dd293f3c7d6cf0c0d.png?ver=12-01-2025']],
+    ['bein Sports 2', ['2023/01/bein-sports-2-full-hd-france.html', 'https://prod-media.beinsports.com/image/a5603bab80b01482a13023b47f67193a.png?ver=12-01-2025']],
+    ['bein Sports 3', ['2023/01/bein-sports-3-full-hd-france.html', 'https://prod-media.beinsports.com/image/d2dec7dfa1b1393f4b5dced45011b955.png?ver=12-01-2025']],
 
     ['RMC Sport 1', ['2023/01/rmc-sport-1-full-hd.html', 'https://i0.wp.com/www.planetecsat.com/wp-content/uploads/2018/07/RMC_SPORT1_PNG_500x500px.png?w=500&ssl=1']],
     ['RMC Sport 2', ['2023/01/rmc-sport-2-full-hd.html', 'https://i0.wp.com/www.planetecsat.com/wp-content/uploads/2018/07/RMC_SPORT2_PNG_500x500px.png?fit=500%2C500&ssl=1']],
 
     ['Canal+', ['2023/01/canal-france-full-hd.html', 'https://thumb.canalplus.pro/http/unsafe/epg.canal-plus.com/mycanal/img/CHN43FN/PNG/213X160/CHN43FB_301.PNG']],
 #    ['Canal+ sport', ['2022/03/canal-sport-full-hd.html', 'https://thumb.canalplus.pro/http/unsafe/epg.canal-plus.com/mycanal/img/CHN43FN/PNG/213X160/CHN43FB_177.PNG']],
-    ['Foot+', ['2022/03/foot-full-hd.html', 'https://matchpint-cdn.matchpint.cloud/shared/imagenes/channels/284_logo_1599851988.png']],
+    ['Foot+', ['2023/01/all-canal-channels-france-full-hd.html', 'https://matchpint-cdn.matchpint.cloud/shared/imagenes/channels/284_logo_1599851988.png']],
 
-    ['eurosport 1', ['2022/03/eurosport-1-full-hd-france.html', 'https://2.bp.blogspot.com/-qEkUoydNN-E/WvMoKma36fI/AAAAAAAAG_0/ov-d571uhZ443Nai7gdU9sSIV2IBOkquQCLcBGAs/s1600/europsort-1-HD.jpg']],
-    ['eurosport 2', ['2022/03/eurosport-2-full-hd-france.html', 'https://4.bp.blogspot.com/-1bHZ8b5ZnW0/VzDh6KfzayI/AAAAAAAABsI/lKDWcPmyBSk7etoAj2DVr7nvQ5SsMPwzgCLcB/s1600/fhuxmcp92wg1w4y9pd2v4zjz3xs1vmjm.jpg']],
+    # ['eurosport 1', ['2022/03/eurosport-1-full-hd-france.html', 'https://2.bp.blogspot.com/-qEkUoydNN-E/WvMoKma36fI/AAAAAAAAG_0/ov-d571uhZ443Nai7gdU9sSIV2IBOkquQCLcBGAs/s1600/europsort-1-HD.jpg']],
+    # ['eurosport 2', ['2022/03/eurosport-2-full-hd-france.html', 'https://4.bp.blogspot.com/-1bHZ8b5ZnW0/VzDh6KfzayI/AAAAAAAABsI/lKDWcPmyBSk7etoAj2DVr7nvQ5SsMPwzgCLcB/s1600/fhuxmcp92wg1w4y9pd2v4zjz3xs1vmjm.jpg']],
 
-    ['L\'equipe TV', ['2022/05/lequipe-tv-full-hd.html', 'https://www.cse.fr/wp-content/uploads/2016/02/LEquipe_logo-300x200-300x150.png']],
-    ['Golf Channel', ['2022/06/golf-full-hd.html', 'https://www.golfchannel.fr/upload/media/golf-channel-600af6fe955c3.png']],
+    ['L\'equipe TV', ['2022/05/l-tv-full-hd.html', 'https://www.cse.fr/wp-content/uploads/2016/02/LEquipe_logo-300x200-300x150.png']],
+    ['Golf Channel', ['2023/01/all-canal-channels-france-full-hd.html', 'https://www.golfchannel.fr/upload/media/golf-channel-600af6fe955c3.png']],
 
-    ['bein Sports MAX 4', ['2022/03/bein-sports-max-4-full-hd-france.html', 'https://images.beinsports.com/owLVmBRH9cHk6K9JSocpTw0Oc4E=/788713-4MAX.png']],
-    ['bein Sports MAX 5', ['2022/03/bein-sports-max-5-full-hd-france.html', 'https://images.beinsports.com/FE2dOGMxn1waqAFYxqsGxXKkvCo=/788714-5MAX.png']],
-    ['bein Sports MAX 6', ['2022/03/bein-sports-max-6-full-hd-france.html', 'https://images.beinsports.com/beNacZewwA5WqFglPAwOaD4n5QA=/788715-6MAX.png']],
-    ['bein Sports MAX 7', ['2022/03/bein-sports-max-7-full-hd-france.html', 'https://images.beinsports.com/6IXXUorOrK_n756SjT6a2Ko7jiM=/788716-7MAX.png']],
-    ['bein Sports MAX 8', ['2022/03/bein-sports-max-8-full-hd-france.html', 'https://images.beinsports.com/6aOfeAugcgMy93nrOfk8NAacALs=/788717-8MAX.png']],
-    ['bein Sports MAX 9', ['2022/03/bein-sports-max-9-full-hd-france.html', 'https://images.beinsports.com/etM_TIm1DmhWr0TZ_CbWGJvaTdQ=/788718-9MAX.png']],
-    ['bein Sports MAX 10', ['2022/03/bein-sports-max-10-full-hd-france.html', 'https://images.beinsports.com/LxFG3ZG88jlFsOyWo_C7o4mdY7M=/788719-10MAX.png']],
+    ['bein Sports MAX 4', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/owLVmBRH9cHk6K9JSocpTw0Oc4E=/788713-4MAX.png']],
+    ['bein Sports MAX 5', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/FE2dOGMxn1waqAFYxqsGxXKkvCo=/788714-5MAX.png']],
+    ['bein Sports MAX 6', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/beNacZewwA5WqFglPAwOaD4n5QA=/788715-6MAX.png']],
+    ['bein Sports MAX 7', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/6IXXUorOrK_n756SjT6a2Ko7jiM=/788716-7MAX.png']],
+    ['bein Sports MAX 8', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/6aOfeAugcgMy93nrOfk8NAacALs=/788717-8MAX.png']],
+    ['bein Sports MAX 9', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/etM_TIm1DmhWr0TZ_CbWGJvaTdQ=/788718-9MAX.png']],
+    ['bein Sports MAX 10', ['2023/01/all-bein-sports-channels-france.html', 'https://images.beinsports.com/LxFG3ZG88jlFsOyWo_C7o4mdY7M=/788719-10MAX.png']],
 
     ['RMC SPORT 3', ['2022/03/rmc-sport-3-full-hd.html', 'https://i0.wp.com/www.planetecsat.com/wp-content/uploads/2018/07/RMC_SPORT3_PNG_500x500px.png?w=500&ssl=1']],
     ['RMC SPORT 4', ['2022/03/rmc-sport-4-full-hd.html', 'https://w0rld.tv/wp-content/uploads/2020/09/rmc-sport-4.png']],
-    ['RMC SPORT LIVE 5', ['2022/03/rmc-sport-live-5-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
-    ['RMC SPORT LIVE 6', ['2022/03/rmc-sport-live-6-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
-    ['RMC SPORT LIVE 7', ['2022/03/rmc-sport-live-7-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
-    ['RMC SPORT LIVE 8', ['2022/03/rmc-sport-live-8-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
-    ['RMC SPORT LIVE 9', ['2022/03/rmc-sport-live-9-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
-    ['RMC SPORT LIVE 10', ['2022/03/rmc-sport-live-10-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']]
+    ['RMC SPORT LIVE 5', ['p/all-sports-tv-channels-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
+    ['RMC SPORT LIVE 6', ['p/all-sports-tv-channels-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
+    ['RMC SPORT LIVE 7', ['p/all-sports-tv-channels-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
+    ['RMC SPORT LIVE 8', ['p/all-sports-tv-channels-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
+    ['RMC SPORT LIVE 9', ['p/all-sports-tv-channels-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']],
+    ['RMC SPORT LIVE 10', ['p/all-sports-tv-channels-full-hd.html', 'https://www.planetecsat.com/wp-content/uploads/2022/09/Entete-RMC-Sport.png']]
 
     ]
 
@@ -288,6 +288,7 @@ def showHoster():
     sTitle = oInputParameterHandler.getValue('sMovieTitle')
     sThumb = oInputParameterHandler.getValue('sThumb')
     sUrl = oInputParameterHandler.getValue('siteUrl')
+    displayHoster = False
     if not sUrl.startswith('http'):
         sUrl = URL_MAIN + sUrl
 
@@ -296,16 +297,31 @@ def showHoster():
     sPattern = '<li movieurl=["\']([^"]+)["\']><a>([^<]+)'
     aResult = oParser.parse(sHtmlContent, sPattern)
 
+    if not aResult[0]:  # si les boutons ne sont pas CH1, CH2, etc, ce sont les noms de chaines
+        sPattern = '<button class="dropbtn" data-src=["\']([^"]+)["\'].*?>([^<]+)'
+        aResult = oParser.parse(sHtmlContent, sPattern)
+        displayHoster = True
     if not aResult[0]:
         oGui.addText(SITE_IDENTIFIER)
     else:
         blackList = ('.tutele.sx', 'leet365', 'casadelfutbol.net', 'yrsport.top', 'cdn.sportcast.life', '.ustreamix.su',
-                     'sportzonline.to', 'sportkart1.xyz', 'olasports.xyz', 'cricplay2.xyz')
+                     'sportzonline.to', 'sportkart1.xyz', 'olasports.xyz', 'cricplay2.xyz', 's2watch.link', 
+                     'cricfree.live', '2024tv.ru', 'sportzlive.shop', 'dlhd.so')
         oOutputParameterHandler = cOutputParameterHandler()
         numLien = 1
-        for aEntry in aResult[1][::-1]:
+        allUrls = []
+        for aEntry in aResult[1]: 
             sUrl = aEntry[0]
-            # hoster = aEntry[1]
+
+            # On retire les doublons
+            sUrl = sUrl.replace( # poscitechs.lol=arlive.shop=footballstreams.lol
+                'poscitechs.lol/live', 'footballstreams.lol/embed'
+            ).replace(
+                'arlive.shop/player', 'footballstreams.lol/embed')
+            if sUrl in allUrls:
+                continue
+            allUrls.append(sUrl)
+
             for out in blackList:
                 if out in sUrl:
                     sUrl = None
@@ -314,7 +330,11 @@ def showHoster():
             if not sUrl:
                 continue
 
-            sDisplayTitle = "%s (Lien %d)" % (sTitle, numLien)
+            if displayHoster:
+                sTitle = aEntry[1]
+                sDisplayTitle = sTitle
+            else:
+                sDisplayTitle = "%s (Lien %d)" % (sTitle, numLien)
             numLien += 1
 
             if 'http' not in sUrl:
@@ -339,13 +359,20 @@ def showLink():
     siterefer = oInputParameterHandler.getValue('siterefer')
     sHosterUrl = ''
 
-# TODO
-#sUrl = "https://stream.crichd.vip/update/euro1.php"
-#sUrl = "https://www.tutelehd.com/online.php?a=3112"
-
-    bvalid, shosterurl = getHosterIframe(sUrl, siterefer)
-    if bvalid:
-        sHosterUrl = shosterurl
+    # Cas particulier : si URL="https://footballstreams.lol/embed/stream-116.php"
+    # l'adresse de lecture est https://zekonew.iosplayer.ru/zeko/premium116/mono.m3u8
+    sPattern = 'https://(footballstreams.lol/embed|poscitechs.lol/live|arlive.shop/player)/stream-([0-9]+).php'
+    result = re.findall(sPattern, sUrl)
+    if result:
+        id = result[0][1]
+        oRequestHandler = cRequestHandler('https://pkpakiplay.xyz/server_lookup.php?channel_id=premium' + id)
+        response = oRequestHandler.request(jsonDecode=True)
+        serverKey = response['server_key']    
+        sHosterUrl = f'https://{serverKey}new.iosplayer.ru/{serverKey}/premium{id}/mono.m3u8|Referer={sUrl}'
+    else:
+        bvalid, shosterurl = getHosterIframe(sUrl, siterefer)
+        if bvalid:
+            sHosterUrl = shosterurl
 
     if sHosterUrl:
         sHosterUrl = sHosterUrl.strip()


### PR DESCRIPTION
- Correction de liens obsolètes de la page d'accueil neymartv
- Ajout de domaines inaccessibles en liste noire
- Gestion des URL pkpakiplay.xyz
- Suppression des liens en doublons
- Certaines images de logo de chaines étaient inaccessibles

En revanche, sans que je ne comprenne pourquoi, la plupart des chaines ne fonctionnent pas selon l'heure alors que l'URL de lecture m3u8 est la bonne et que la vidéo s'affiche bien dans le navigateur. Si vous avez une idée de la cause, j'aimerais que vous regardiez. Sinon, merci d'intégrer la PR, qui rend quand même la source neymartv un peu plus fonctionnelle qu'avant.