### PR TITLE
MAJ radios

### DIFF
--- a/plugin.video.vstream/resources/extra/radio.xspf
+++ b/plugin.video.vstream/resources/extra/radio.xspf
@@ -539,7 +539,7 @@
 		</track>
 		<track>
 			<location>http://direct.mouv.fr/live/mouv-midfi.mp3</location>
-			<title>Mouv''</title>
+			<title>Mouv'</title>
 			<image>https://i3.radionomy.com/radios/200/e90dfa5c-105a-456a-b69b-cf903a07a96d.jpg</image>
 			<identifier>Hip-hop</identifier>
 		</track>


### PR DESCRIPTION
- mise à jour des flux radiofrance (passage en hifi/AAC)
- ajout des webradios FIP manquantes

1) Serait-il possibile de stocker sur le repo les icônes des radios pour éviter qu'elles disparaissent (liens morts)  ? Dans l'attente d'une réponse, je n'ai pas ajouté les < image > </ image > (balises ?). 

2) Le lecteur prend-il en change le support des métadonnées des flux (obtenues via l'api des radios) ? Example pour France Inter : https://www.radiofrance.fr/franceinter/api/live? 
Si oui, quel < ???? > https://www.radiofrance.fr/franceinter/api/live? < /???? > utiliser ?