### PR TITLE
cpasmal + cpasmieux - Correction du type de URL_SEARCH

### DIFF
--- a/plugin.video.vstream/resources/sites/cpasmal.py
+++ b/plugin.video.vstream/resources/sites/cpasmal.py
@@ -26,7 +26,7 @@ SERIE_SERIES = ('series-streaming/', 'showMenuTvShows')
 SERIE_NEWS = ('series-streaming/', 'showMovies')
 SERIE_GENRES = (SERIE_SERIES[0] , 'showSerieGenres')
 
-URL_SEARCH = (False, 'showMovies')
+URL_SEARCH = ('', 'showMovies')
 URL_SEARCH_MOVIES = ('index.php?do=search&subaction=search&search_start=0&full_search=0&result_from=1&story=%s&cat=Film', 'showMovies')
 URL_SEARCH_SERIES = ('index.php?do=search&subaction=search&search_start=0&full_search=0&result_from=1&story=%s&cat=Serie', 'showMovies')
 FUNCTION_SEARCH = 'showMovies'

--- a/plugin.video.vstream/resources/sites/cpasmieux.py
+++ b/plugin.video.vstream/resources/sites/cpasmieux.py
@@ -26,7 +26,7 @@ SERIE_SERIES = ('seriestreaming/', 'showMenuTvShows')
 SERIE_NEWS = ('seriestreaming/', 'showMovies')
 SERIE_GENRES = (SERIE_SERIES[0] , 'showSerieGenres')
 
-URL_SEARCH = (False, 'showMovies')
+URL_SEARCH = ('', 'showMovies')
 URL_SEARCH_MOVIES = ('search/%s&cat=movie', 'showMovies')
 URL_SEARCH_SERIES = ('search/%s&cat=tv', 'showMovies')
 URL_SEARCH_ANIMS = ('search/%s&cat=anime', 'showMovies')


### PR DESCRIPTION
Le répartiteur de recherche concatène URL_SEARCH[0] avec les termes saisis (sUrl = URL_MAIN + URL_SEARCH[0] + termes[0]). Avec False (booléen) comme premier élément, la concaténation lève une TypeError avant tout routage par catégorie : la recherche ne renvoie donc rien pour ces deux sites.

On utilise '' (chaîne vide) afin que le répartiteur retombe proprement sur URL_SEARCH_MOVIES / URL_SEARCH_SERIES.