### PR TITLE
Ajoute la source 1jour1film (+ hoster SeekStreaming)

### DIFF
--- a/plugin.video.vstream/resources/hosters/seekstreaming.py
+++ b/plugin.video.vstream/resources/hosters/seekstreaming.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# vStream https://github.com/Kodi-vStream/venom-xbmc-addons
+# SeekStreaming / Embed4me family player (p2pstream, ezplayer, embed4me,
+# embedseek, seekplayer, seekplays, uns.bio ...). Used by 1jour1film.
+#
+# Flow: embed URL carries the video id in the #fragment
+#   https://marcus.p2pstream.vip/#hdxxgm  ->  id = hdxxgm
+# The API returns an AES-CBC (static key/iv) hex blob:
+#   GET https://{domain}/api/v1/video?id={id}&w=1920&h=1080&r=
+# Decrypted JSON exposes two HLS playlists:
+#   source   -> raw-IP origin (geo/IP locked, cert won't match -> verifypeer=false)
+#   cfNative -> CDN route via the embed domain (.m3u8, proper cert) = "normale"
+#   cf       -> CDN .txt playlist (fallback for "normale")
+from urllib.parse import urlparse
+
+from resources.hosters.hoster import iHoster
+from resources.lib.handler.requestHandler import cRequestHandler
+from resources.lib.comaddon import dialog, VSlog
+
+import binascii
+import json
+
+from Cryptodome.Cipher import AES
+
+UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+# Static AES-CBC key/iv baked into the seekstreaming player bundle.
+AES_KEY = b'kiemtienmua911ca'
+AES_IV = b'1234567890oiuytr'
+
+
+class cHoster(iHoster):
+
+    def __init__(self):
+        iHoster.__init__(self, 'seekstreaming', 'SeekStreaming')
+
+    def setUrl(self, url):
+        # Keep the #fragment (it carries the video id) - iHoster.setUrl drops nothing,
+        # but the generic http-prefixer is fine here.
+        super(cHoster, self).setUrl(url)
+
+    def _decrypt(self, hexStr):
+        try:
+            data = binascii.unhexlify(hexStr.strip().replace('"', ''))
+            dec = AES.new(AES_KEY, AES.MODE_CBC, AES_IV).decrypt(data)
+            dec = dec[:-dec[-1]]  # strip PKCS7 padding
+            return dec.decode('utf-8', 'replace')
+        except Exception as e:
+            VSlog('[SEEKSTREAMING] decrypt error: %s' % str(e))
+            return None
+
+    def _getMediaLinkForGuest(self):
+        sUrl = self._url
+
+        # video id: after #fragment, else /embed/<id>, else last path segment
+        videoId = ''
+        if '#' in sUrl:
+            videoId = sUrl.split('#')[-1].strip()
+        else:
+            parsed = urlparse(sUrl)
+            if parsed.fragment:
+                videoId = parsed.fragment.strip()
+            elif '/embed/' in sUrl.lower():
+                videoId = sUrl.rstrip('/').split('/')[-1].strip()
+            elif parsed.path and parsed.path != '/':
+                videoId = parsed.path.rstrip('/').split('/')[-1].strip()
+        if not videoId:
+            return False, False
+
+        domain = urlparse(sUrl).netloc
+        if not domain:
+            return False, False
+
+        apiUrl = 'https://%s/api/v1/video?id=%s&w=1920&h=1080&r=' % (domain, videoId)
+        oRequest = cRequestHandler(apiUrl)
+        oRequest.addHeaderEntry('User-Agent', UA)
+        oRequest.addHeaderEntry('Accept', '*/*')
+        oRequest.addHeaderEntry('Referer', 'https://%s/' % domain)
+        oRequest.addHeaderEntry('Origin', 'https://%s' % domain)
+        sContent = oRequest.request(jsonDecode=False)
+        if not sContent:
+            return False, False
+
+        raw = self._decrypt(sContent)
+        if not raw:
+            return False, False
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            return False, False
+
+        # "normale" (CDN) preferred as cfNative (.m3u8, proper cert), else cf (.txt)
+        normale = data.get('cfNative') or data.get('cf')
+        ipStream = data.get('source')
+
+        # Headers carried to Kodi's player; verifypeer=false covers the raw-IP cert.
+        suffix = '|User-Agent=%s&Referer=https://%s/&Origin=https://%s&verifypeer=false' % (UA, domain, domain)
+
+        quals = []
+        urls = []
+        if normale:
+            quals.append('Normale (CDN)')
+            urls.append(normale + suffix)
+        if ipStream:
+            quals.append('IP direct')
+            urls.append(ipStream + suffix)
+
+        if not urls:
+            return False, False
+
+        api_call = dialog().VSselectqual(quals, urls)
+        if api_call:
+            return True, api_call
+
+        return False, False

--- a/plugin.video.vstream/resources/lib/gui/hoster.py
+++ b/plugin.video.vstream/resources/lib/gui/hoster.py
@@ -178,6 +178,12 @@ class cHosterGui:
         if any(x in sHosterUrl for x in ['.mp4', '.avi', '.flv', '.m3u8', '.webm', '.mkv', '.mpd']):
             return self.getHoster('lien_direct')
 
+        # SeekStreaming par la forme : http(s)://<host>/#<id> (# juste après le
+        # premier /). Rotation-proof, avant le debrideur (qui ne sait pas résoudre).
+        rest = fullURL.split('://', 1)[-1]
+        if '/' in rest and rest.split('/', 1)[1].startswith('#'):
+            return self.getHoster('seekstreaming')
+
         # Petit nettoyage
         sHosterUrl = sHosterUrl.split('|')[0]
         sHosterUrl = sHosterUrl.split('?')[0]
@@ -278,8 +284,14 @@ class cHosterGui:
             return self.getHoster('lulustream')         
 
         if ('savefiles' in sHostName) or ('streamhls' in sHostName):
-            return self.getHoster('savefiles')      
-            
+            return self.getHoster('savefiles')
+
+        # SeekStreaming / Embed4me family (rotating base domains). Used by 1jour1film.
+        # New base domains appear over time - add them here as they rotate.
+        if any(x in sHostName for x in ('p2pstream', 'ezplayer', 'uns.bio', 'rpmlive', 'embed4me', 'embedseek',
+                                        'seekplayer', 'seekplays', 'seeks.cloud', 'servicecatalog', 'technicalcatalog')):
+            return self.getHoster('seekstreaming')
+
         if ('swish' in sHostName) or ('hanerix' in sHostName) or ('hgcloud' in sHostName):
             return self.getHoster('swish')
         

--- a/plugin.video.vstream/resources/sites.json
+++ b/plugin.video.vstream/resources/sites.json
@@ -1,5 +1,11 @@
 {
     "sites": {
+        "_1jour1film": {
+            "label": "1jour1film",
+            "active": "True",
+            "site_info": "https://1jour1film2026.site/go/",
+            "url": "https://1jour1film0726.site/"
+        },
         "_1seriestreaming": {
             "label": "1 SerieStreaming",
             "active": "False",

--- a/plugin.video.vstream/resources/sites/_1jour1film.py
+++ b/plugin.video.vstream/resources/sites/_1jour1film.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+# vStream https://github.com/Kodi-vStream/venom-xbmc-addons
+# 1jour1film (1J1F) - Dooplay/WordPress. Domaine tournant, resolu via /go/.
+#
+# Les listes de lecteurs ne sont PAS dans le HTML brut : elles sont base64 dans
+# des <script src="data:text/javascript;base64,...">.
+#   Films  : var J1F_SRV     = [{label, url, type, source}, ...]
+#   Series : var j1fEpsData  = [{num, label, servers:[{label, u|url, type}]}]
+# Les lecteurs "manual" sont de la famille SeekStreaming (hoster seekstreaming.py).
+import re
+import base64
+import json
+from urllib.parse import urlparse
+
+from resources.lib.gui.hoster import cHosterGui
+from resources.lib.gui.gui import cGui
+from resources.lib.handler.inputParameterHandler import cInputParameterHandler
+from resources.lib.handler.outputParameterHandler import cOutputParameterHandler
+from resources.lib.handler.requestHandler import cRequestHandler
+from resources.lib.parser import cParser
+from resources.lib.comaddon import siteManager, VSlog
+from resources.lib.util import cUtil
+
+UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+SITE_IDENTIFIER = '_1jour1film'
+SITE_NAME = '1jour1film'
+SITE_DESC = 'Films & Séries en streaming VF/VOSTFR'
+
+# Menu global HOME
+MOVIE_MOVIE = (True, 'showMenuMovies')
+SERIE_SERIES = (True, 'showMenuTvShows')
+
+# Recherche (drive la recherche globale vStream). Préfixe vide : la fonction
+# reçoit le texte recherché directement (cf. search.py _pluginSearch).
+URL_SEARCH = ('', 'showMovies')
+URL_SEARCH_MOVIES = ('', 'showMovies')
+URL_SEARCH_SERIES = ('', 'showSeries')
+
+MOVIE_NEWS = ('', 'showMovies')     # page d'accueil = nouveautes
+SERIE_NEWS = ('', 'showSeries')
+
+# Cartes (recherche j1f-search-card ET accueil/genre j1f-card) - un seul motif.
+CARD_PATTERN = (r'<a href="([^"]+/(?:films|tvshows)/[^"]+)" class="j1f-(?:search-)?card">'
+                r'.+?src="(https://image\.tmdb\.org/[^"]+)".+?__title">([^<]+)</div>')
+
+
+# === Réseau : le site gate sur des en-têtes navigateur complets ===
+def _getHtml(sUrl):
+    oRequest = cRequestHandler(sUrl)
+    oRequest.addHeaderEntry('User-Agent', UA)
+    oRequest.addHeaderEntry('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
+    oRequest.addHeaderEntry('Accept-Language', 'fr-FR,fr;q=0.9,en;q=0.8')
+    oRequest.addHeaderEntry('Sec-Fetch-Mode', 'navigate')
+    return oRequest.request()
+
+
+# === Résolution du domaine (le domaine tourne, /go/ pointe le domaine actif) ===
+def getUrlMain():
+    siteInfo = siteManager().getDefaultProperty(SITE_IDENTIFIER, 'site_info')
+    if siteInfo:
+        try:
+            html = _getHtml(siteInfo)
+            m = re.search(r'TARGET_URL\s*=\s*"([^"]+)"', html)
+            if m:
+                base = m.group(1).replace('\\/', '/').rstrip('/')
+                return base + '/'
+        except Exception as e:
+            VSlog('[1J1F] getUrlMain: %s' % str(e))
+    return siteManager().getUrlMain(SITE_IDENTIFIER)
+
+
+# === Décodage des lecteurs (base64 dans les data: scripts) ===
+def _decodeDataScripts(html):
+    out = []
+    for m in re.finditer(r'data:text/javascript;base64,([A-Za-z0-9+/=]+)', html):
+        try:
+            out.append(base64.b64decode(m.group(1)).decode('utf-8', 'replace'))
+        except Exception:
+            pass
+    return out
+
+
+def _extractJsArray(html, varName):
+    pat = re.compile(r'(?:var|let|const)\s+' + re.escape(varName) + r'\s*=\s*(\[[\s\S]*?\])\s*;')
+    for js in _decodeDataScripts(html) + [html]:   # data: scripts d'abord, page brute en secours
+        m = pat.search(js)
+        if m:
+            try:
+                return json.loads(m.group(1))
+            except Exception:
+                pass
+    return None
+
+
+def _decodeUrl(u):
+    # Le champ url/u est souvent base64 ; laisse tel quel s'il est déjà en http(s).
+    if not isinstance(u, str) or not u:
+        return ''
+    if re.match(r'^https?://', u, re.I):
+        return u
+    try:
+        dec = base64.b64decode(u).decode('utf-8')
+        return dec if re.match(r'^https?://', dec, re.I) else ''
+    except Exception:
+        return ''
+
+
+def _isSeekShape(url):
+    # Embed SeekStreaming : https://<host>/#<id> (id dans le fragment, path vide).
+    p = urlparse(url)
+    return bool(p.fragment) and (not p.path or p.path == '/')
+
+
+def _yearFromUrl(sUrl):
+    m = re.search(r'-(\d{4})(?:[-/]|$)', sUrl)
+    return m.group(1) if m else ''
+
+
+def _routeServers(oGui, servers, sTitle, sThumb):
+    oHosterGui = cHosterGui()
+    for s in servers or []:
+        if not isinstance(s, dict):
+            continue
+        url = _decodeUrl(s.get('url') or s.get('u') or '')
+        if not url:
+            continue
+        source = str(s.get('source') or '').lower()
+        label = s.get('label') or ''
+        # "manual" (ou forme d'embed seek) => SeekStreaming, sinon routage classique.
+        if source == 'manual' or _isSeekShape(url):
+            oHoster = oHosterGui.getHoster('seekstreaming')
+        else:
+            oHoster = oHosterGui.checkHoster(url)
+        if not oHoster:
+            continue
+        sDisplay = ('%s [%s]' % (sTitle, label)).strip() if label else sTitle
+        oHoster.setDisplayName(sDisplay)
+        oHoster.setFileName(sTitle)
+        oHosterGui.showHoster(oGui, oHoster, url, sThumb)
+
+
+# === Menus ===
+def load():
+    oGui = cGui()
+    oOut = cOutputParameterHandler()
+    oOut.addParameter('siteUrl', MOVIE_MOVIE[0])
+    oGui.addDir(SITE_IDENTIFIER, MOVIE_MOVIE[1], 'Films', 'films.png', oOut)
+    oOut.addParameter('siteUrl', SERIE_SERIES[0])
+    oGui.addDir(SITE_IDENTIFIER, SERIE_SERIES[1], 'Séries', 'series.png', oOut)
+    oGui.setEndOfDirectory()
+
+
+def showMenuMovies():
+    oGui = cGui()
+    oOut = cOutputParameterHandler()
+    oOut.addParameter('siteUrl', 'film')
+    oGui.addDir(SITE_IDENTIFIER, 'showSearch', 'Rechercher', 'search.png', oOut)
+    oOut.addParameter('siteUrl', 'home')
+    oGui.addDir(SITE_IDENTIFIER, 'showMovies', 'Nouveautés', 'news.png', oOut)
+    oGui.setEndOfDirectory()
+
+
+def showMenuTvShows():
+    oGui = cGui()
+    oOut = cOutputParameterHandler()
+    oOut.addParameter('siteUrl', 'serie')
+    oGui.addDir(SITE_IDENTIFIER, 'showSearch', 'Rechercher', 'search.png', oOut)
+    oOut.addParameter('siteUrl', 'home')
+    oGui.addDir(SITE_IDENTIFIER, 'showSeries', 'Nouveautés', 'news.png', oOut)
+    oGui.setEndOfDirectory()
+
+
+def showSearch():
+    oGui = cGui()
+    sSearch = oGui.showKeyBoard()
+    if sSearch:
+        sUrl = cInputParameterHandler().getValue('siteUrl')
+        if sUrl and 'serie' in sUrl:
+            showSeries(sSearch)
+        else:
+            showMovies(sSearch)
+        oGui.setEndOfDirectory()
+        return
+
+
+def showMovies(sSearch=''):
+    _showResults(sSearch, 'movie')
+
+
+def showSeries(sSearch=''):
+    _showResults(sSearch, 'tv')
+
+
+def _showResults(sSearch, wantType):
+    oGui = cGui()
+    oParser = cParser()
+    oUtil = cUtil()
+    URL_MAIN = getUrlMain()
+
+    sSearchText = ''
+    if sSearch:
+        # sSearch peut arriver déjà url-quoté (%20) via la recherche globale.
+        sSearchText = oUtil.CleanName(sSearch.replace('%20', ' '))
+        sUrl = URL_MAIN + '?s=' + sSearch.replace(' ', '+')
+    else:
+        # 'home' (ou vide) = page d'accueil = nouveautés
+        sUrl = URL_MAIN
+
+    html = _getHtml(sUrl)
+    aResult = oParser.parse(html, CARD_PATTERN)
+
+    if aResult[0]:
+        seen = set()
+        oOut = cOutputParameterHandler()
+        for aEntry in aResult[1]:
+            sMovieUrl = aEntry[0]
+            isMovie = '/films/' in sMovieUrl
+            if wantType == 'movie' and not isMovie:
+                continue
+            if wantType == 'tv' and isMovie:
+                continue
+            if sMovieUrl in seen:
+                continue
+            seen.add(sMovieUrl)
+
+            sThumb = aEntry[1]
+            sTitle = oUtil.unescape(aEntry[2]).strip()
+            if sSearch and not oUtil.CheckOccurence(sSearchText, sTitle):
+                continue
+
+            sYear = _yearFromUrl(sMovieUrl)
+            oOut.addParameter('siteUrl', sMovieUrl)
+            oOut.addParameter('sMovieTitle', sTitle)
+            oOut.addParameter('sThumb', sThumb)
+            oOut.addParameter('sYear', sYear)
+
+            if isMovie:
+                oGui.addMovie(SITE_IDENTIFIER, 'showMovieHosters', sTitle, '', sThumb, '', oOut)
+            else:
+                oGui.addTV(SITE_IDENTIFIER, 'showSaisons', sTitle, '', sThumb, '', oOut)
+    else:
+        oGui.addText(SITE_IDENTIFIER)
+
+    if not sSearch:
+        oGui.setEndOfDirectory()
+
+
+# === Films : page -> J1F_SRV -> lecteurs ===
+def showMovieHosters():
+    oGui = cGui()
+    oIn = cInputParameterHandler()
+    sUrl = oIn.getValue('siteUrl')
+    sTitle = oIn.getValue('sMovieTitle')
+    sThumb = oIn.getValue('sThumb')
+
+    html = _getHtml(sUrl)
+    srv = _extractJsArray(html, 'J1F_SRV')
+    if srv:
+        _routeServers(oGui, srv, sTitle, sThumb)
+    else:
+        oGui.addText(SITE_IDENTIFIER)
+    oGui.setEndOfDirectory()
+
+
+# === Séries : tvshow -> saisons -> j1fEpsData -> episodes -> lecteurs ===
+def showSaisons():
+    oGui = cGui()
+    oParser = cParser()
+    oIn = cInputParameterHandler()
+    sUrl = oIn.getValue('siteUrl')
+    sThumb = oIn.getValue('sThumb')
+    sDesc = oIn.getValue('sDesc')
+    sTitle = oIn.getValue('sMovieTitle')
+
+    html = _getHtml(sUrl)
+    aResult = oParser.parse(html, r'href="([^"]+/saisons/[^"]*saison-(\d+)[^"]*)"')
+
+    if aResult[0]:
+        seen = set()
+        oOut = cOutputParameterHandler()
+        for aEntry in aResult[1]:
+            sSeasonUrl = aEntry[0]
+            sSeason = aEntry[1]
+            if sSeason in seen:
+                continue
+            seen.add(sSeason)
+            sSeasonTitle = '%s - Saison %s' % (sTitle, sSeason)
+            oOut.addParameter('siteUrl', sSeasonUrl)
+            oOut.addParameter('sMovieTitle', sSeasonTitle)
+            oOut.addParameter('sThumb', sThumb)
+            oOut.addParameter('sDesc', sDesc)
+            oOut.addParameter('sSeason', sSeason)
+            oGui.addSeason(SITE_IDENTIFIER, 'showEpisodes', sSeasonTitle, '', sThumb, sDesc, oOut)
+    else:
+        oGui.addText(SITE_IDENTIFIER)
+    oGui.setEndOfDirectory()
+
+
+def showEpisodes():
+    oGui = cGui()
+    oIn = cInputParameterHandler()
+    sUrl = oIn.getValue('siteUrl')
+    sThumb = oIn.getValue('sThumb')
+    sDesc = oIn.getValue('sDesc')
+    sTitle = oIn.getValue('sMovieTitle')       # "<titre> - Saison N"
+    sSeason = oIn.getValue('sSeason')
+
+    html = _getHtml(sUrl)
+    eps = _extractJsArray(html, 'j1fEpsData')
+
+    if eps:
+        oOut = cOutputParameterHandler()
+        for e in eps:
+            if not isinstance(e, dict):
+                continue
+            sNum = str(e.get('num') or '')
+            if not sNum:
+                continue
+            sLabel = e.get('label') or ''
+            sEpTitle = '%s Episode %s' % (sTitle, sNum)
+            sDisplay = ('%s - %s' % (sEpTitle, sLabel)) if sLabel else sEpTitle
+            oOut.addParameter('siteUrl', sUrl)
+            oOut.addParameter('sMovieTitle', sEpTitle)
+            oOut.addParameter('sThumb', sThumb)
+            oOut.addParameter('sSeason', sSeason)
+            oOut.addParameter('sEpisode', sNum)
+            oGui.addEpisode(SITE_IDENTIFIER, 'showEpisodeHosters', sDisplay, '', sThumb, sDesc, oOut)
+    else:
+        oGui.addText(SITE_IDENTIFIER)
+    oGui.setEndOfDirectory()
+
+
+def showEpisodeHosters():
+    oGui = cGui()
+    oIn = cInputParameterHandler()
+    sUrl = oIn.getValue('siteUrl')
+    sThumb = oIn.getValue('sThumb')
+    sTitle = oIn.getValue('sMovieTitle')
+    sEpisode = str(oIn.getValue('sEpisode'))
+
+    html = _getHtml(sUrl)
+    eps = _extractJsArray(html, 'j1fEpsData')
+
+    servers = []
+    if eps:
+        for e in eps:
+            if isinstance(e, dict) and str(e.get('num') or '') == sEpisode:
+                servers = e.get('servers') or []
+                break
+
+    if servers:
+        _routeServers(oGui, servers, sTitle, sThumb)
+    else:
+        oGui.addText(SITE_IDENTIFIER)
+    oGui.setEndOfDirectory()


### PR DESCRIPTION
## Ajoute la source 1jour1film (1J1F)

Films & séries en streaming VF/VOSTFR, avec le resolver des lecteurs associés.

### Ce que ça ajoute

- **`resources/sites/_1jour1film.py`** — module site (Dooplay/WordPress). Domaine tournant résolu automatiquement via `/go/`. Recherche + nouveautés pour films et séries, intégré à la recherche globale.
- **`resources/hosters/seekstreaming.py`** — resolver de la famille SeekStreaming / embed4me (utilisée par 1J1F sous des domaines tournants : `p2pstream`, `ezplayer`, `rpmlive`, `uns.bio`…). Réutilisable par n'importe quel site.
- **`resources/lib/gui/hoster.py`** — `checkHoster` route vers seekstreaming.
- **`resources/sites.json`** — entrée `_1jour1film`.

### Détails techniques

Les listes de lecteurs ne sont pas dans le HTML brut : elles sont encodées en base64 dans des `<script src="data:text/javascript;base64,…">` (`J1F_SRV` pour les films, `j1fEpsData` pour les épisodes).

Les lecteurs « manual » sont de la famille SeekStreaming : l'ID vidéo est dans le fragment de l'URL (`https://host/#id`). L'API `/api/v1/video?id=` renvoie un blob AES-CBC (clé statique) qui expose **deux flux HLS** :
- `source` → flux IP direct (origine, cert sur IP → `verifypeer=false`)
- `cfNative` / `cf` → flux CDN « normale »

Les deux qualités sont proposées via `VSselectqual`.

Le routage vers seekstreaming est **rotation-proof** : détection par la forme `http(s)://host/#id` (avant le debrideur, qui ne sait pas résoudre ces lecteurs), plus une liste de domaines-base connus en secours.

### Tests

Vérifié de bout en bout sur le site live :
- Résolution du domaine via `/go/`
- Recherche → cartes films + séries (titres, affiches)
- **Film** : page → `J1F_SRV` → décrypt AES → m3u8 jouable (`#EXTM3U`)
- **Série** : saisons → `j1fEpsData` → décrypt → m3u8 jouable (`#EXTM3U`)
- Intégration recherche globale (films cat 1/7, séries cat 2/4/8)
- Compilation sans warning, `sites.json` valide

### Limites connues

- Les domaines des lecteurs tournent ; la détection par forme `/#id` couvre la rotation, la liste de domaines-base est à compléter si un nouveau apparaît.
- Clé AES statique du bundle SeekStreaming : casse si elle change côté site.

Il reste plus qu'a tester sur kodi

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
